### PR TITLE
Fix type warnings

### DIFF
--- a/src/DCCEXProtocol.cpp
+++ b/src/DCCEXProtocol.cpp
@@ -1624,12 +1624,12 @@ bool DCCEXProtocol::splitFunctions(char *cmd) {
 
 bool DCCEXProtocol::stripLeadAndTrailQuotes(char* rslt, char* text) {
     if (text[0]=='"' && text[strlen(text)-1]=='"') {
-        for(int i=1; i<strlen(text)-1; i++) {
+        for(size_t i=1; i<strlen(text)-1; i++) {
             rslt[i-1] = text[i];
         }
         rslt[strlen(text)-2]='\0';
     } else {
-        for(int i=0; i<strlen(text); i++) {
+        for(size_t i=0; i<strlen(text); i++) {
             rslt[i] = text[i];
         }
         rslt[strlen(text)]='\0';


### PR DESCRIPTION
Fixed type warnings in DCCEXProtocol::stripLeadAndTrailQuotes for int vs. size_t