### PR TITLE
Make DCCEXProtocol cross platform

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,225 @@
+---
+Language:        Cpp
+# BasedOnStyle:  LLVM
+AccessModifierOffset: -2
+AlignAfterOpenBracket: Align
+AlignArrayOfStructures: None
+AlignConsecutiveAssignments:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  PadOperators:    true
+AlignConsecutiveBitFields:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  PadOperators:    false
+AlignConsecutiveDeclarations:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  PadOperators:    false
+AlignConsecutiveMacros:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  PadOperators:    false
+AlignEscapedNewlines: Right
+AlignOperands:   Align
+AlignTrailingComments:
+  Kind:            Always
+  OverEmptyLines:  0
+AllowAllArgumentsOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortEnumsOnASingleLine: true
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLambdasOnASingleLine: All
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: MultiLine
+AttributeMacros:
+  - __capability
+BinPackArguments: true
+BinPackParameters: true
+BitFieldColonSpacing: Both
+BraceWrapping:
+  AfterCaseLabel:  false
+  AfterClass:      false
+  AfterControlStatement: Never
+  AfterEnum:       false
+  AfterExternBlock: false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  BeforeCatch:     false
+  BeforeElse:      false
+  BeforeLambdaBody: false
+  BeforeWhile:     false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakAfterAttributes: Never
+BreakAfterJavaFieldAnnotations: false
+BreakArrays:     true
+BreakBeforeBinaryOperators: None
+BreakBeforeConceptDeclarations: Always
+BreakBeforeBraces: Attach
+BreakBeforeInlineASMColon: OnlyMultiline
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializers: BeforeColon
+BreakInheritanceList: BeforeColon
+BreakStringLiterals: true
+ColumnLimit:     80
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+DisableFormat:   false
+EmptyLineAfterAccessModifier: Never
+EmptyLineBeforeAccessModifier: LogicalBlock
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IfMacros:
+  - KJ_IF_MAYBE
+IncludeBlocks:   Preserve
+IncludeCategories:
+  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority:        2
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '^(<|"(gtest|gmock|isl|json)/)'
+    Priority:        3
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '.*'
+    Priority:        1
+    SortPriority:    0
+    CaseSensitive:   false
+IncludeIsMainRegex: '(Test)?$'
+IncludeIsMainSourceRegex: ''
+IndentAccessModifiers: false
+IndentCaseBlocks: false
+IndentCaseLabels: false
+IndentExternBlock: AfterExternBlock
+IndentGotoLabels: true
+IndentPPDirectives: None
+IndentRequiresClause: true
+IndentWidth:     2
+IndentWrappedFunctionNames: false
+InsertBraces:    false
+InsertNewlineAtEOF: false
+InsertTrailingCommas: None
+IntegerLiteralSeparator:
+  Binary:          0
+  BinaryMinDigits: 0
+  Decimal:         0
+  DecimalMinDigits: 0
+  Hex:             0
+  HexMinDigits:    0
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: true
+LambdaBodyIndentation: Signature
+LineEnding:      DeriveLF
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBinPackProtocolList: Auto
+ObjCBlockIndentWidth: 2
+ObjCBreakBeforeNestedBlockParam: true
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PackConstructorInitializers: BinPack
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakOpenParenthesis: 0
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyIndentedWhitespace: 0
+PenaltyReturnTypeOnItsOwnLine: 60
+PointerAlignment: Right
+PPIndentWidth:   -1
+QualifierAlignment: Leave
+ReferenceAlignment: Pointer
+ReflowComments:  true
+RemoveBracesLLVM: false
+RemoveSemicolon: false
+RequiresClausePosition: OwnLine
+RequiresExpressionIndentation: OuterScope
+SeparateDefinitionBlocks: Leave
+ShortNamespaceLines: 1
+SortIncludes:    CaseSensitive
+SortJavaStaticImport: Before
+SortUsingDeclarations: LexicographicNumeric
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceAroundPointerQualifiers: Default
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCaseColon: false
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeParensOptions:
+  AfterControlStatements: true
+  AfterForeachMacros: true
+  AfterFunctionDefinitionName: false
+  AfterFunctionDeclarationName: false
+  AfterIfMacros:   true
+  AfterOverloadedOperator: false
+  AfterRequiresInClause: false
+  AfterRequiresInExpression: false
+  BeforeNonEmptyParentheses: false
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceBeforeSquareBrackets: false
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  Never
+SpacesInConditionalStatement: false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInLineCommentPrefix:
+  Minimum:         1
+  Maximum:         -1
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Latest
+StatementAttributeLikeMacros:
+  - Q_EMIT
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+TabWidth:        8
+UseTab:          Never
+WhitespaceSensitiveMacros:
+  - BOOST_PP_STRINGIZE
+  - CF_SWIFT_NAME
+  - NS_SWIFT_NAME
+  - PP_STRINGIZE
+  - STRINGIZE
+...
+

--- a/.clang-format
+++ b/.clang-format
@@ -3,223 +3,135 @@ Language:        Cpp
 # BasedOnStyle:  LLVM
 AccessModifierOffset: -2
 AlignAfterOpenBracket: Align
-AlignArrayOfStructures: None
-AlignConsecutiveAssignments:
-  Enabled:         false
-  AcrossEmptyLines: false
-  AcrossComments:  false
-  AlignCompound:   false
-  PadOperators:    true
-AlignConsecutiveBitFields:
-  Enabled:         false
-  AcrossEmptyLines: false
-  AcrossComments:  false
-  AlignCompound:   false
-  PadOperators:    false
-AlignConsecutiveDeclarations:
-  Enabled:         false
-  AcrossEmptyLines: false
-  AcrossComments:  false
-  AlignCompound:   false
-  PadOperators:    false
-AlignConsecutiveMacros:
-  Enabled:         false
-  AcrossEmptyLines: false
-  AcrossComments:  false
-  AlignCompound:   false
-  PadOperators:    false
+AlignConsecutiveMacros: false
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
 AlignEscapedNewlines: Right
-AlignOperands:   Align
-AlignTrailingComments:
-  Kind:            Always
-  OverEmptyLines:  0
+AlignOperands:   true
+AlignTrailingComments: true
 AllowAllArgumentsOnNextLine: true
+AllowAllConstructorInitializersOnNextLine: true
 AllowAllParametersOfDeclarationOnNextLine: true
 AllowShortBlocksOnASingleLine: Never
 AllowShortCaseLabelsOnASingleLine: false
-AllowShortEnumsOnASingleLine: true
 AllowShortFunctionsOnASingleLine: All
-AllowShortIfStatementsOnASingleLine: Never
 AllowShortLambdasOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: Never
 AllowShortLoopsOnASingleLine: false
 AlwaysBreakAfterDefinitionReturnType: None
 AlwaysBreakAfterReturnType: None
 AlwaysBreakBeforeMultilineStrings: false
 AlwaysBreakTemplateDeclarations: MultiLine
-AttributeMacros:
-  - __capability
 BinPackArguments: true
 BinPackParameters: true
-BitFieldColonSpacing: Both
 BraceWrapping:
   AfterCaseLabel:  false
   AfterClass:      false
-  AfterControlStatement: Never
+  AfterControlStatement: false
   AfterEnum:       false
-  AfterExternBlock: false
   AfterFunction:   false
   AfterNamespace:  false
   AfterObjCDeclaration: false
   AfterStruct:     false
   AfterUnion:      false
+  AfterExternBlock: false
   BeforeCatch:     false
   BeforeElse:      false
-  BeforeLambdaBody: false
-  BeforeWhile:     false
   IndentBraces:    false
   SplitEmptyFunction: true
   SplitEmptyRecord: true
   SplitEmptyNamespace: true
-BreakAfterAttributes: Never
-BreakAfterJavaFieldAnnotations: false
-BreakArrays:     true
 BreakBeforeBinaryOperators: None
-BreakBeforeConceptDeclarations: Always
 BreakBeforeBraces: Attach
-BreakBeforeInlineASMColon: OnlyMultiline
-BreakBeforeTernaryOperators: true
-BreakConstructorInitializers: BeforeColon
+BreakBeforeInheritanceComma: false
 BreakInheritanceList: BeforeColon
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeColon
+BreakAfterJavaFieldAnnotations: false
 BreakStringLiterals: true
 ColumnLimit:     80
 CommentPragmas:  '^ IWYU pragma:'
 CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
 ConstructorInitializerIndentWidth: 4
 ContinuationIndentWidth: 4
 Cpp11BracedListStyle: true
+DeriveLineEnding: true
 DerivePointerAlignment: false
 DisableFormat:   false
-EmptyLineAfterAccessModifier: Never
-EmptyLineBeforeAccessModifier: LogicalBlock
 ExperimentalAutoDetectBinPacking: false
 FixNamespaceComments: true
 ForEachMacros:
   - foreach
   - Q_FOREACH
   - BOOST_FOREACH
-IfMacros:
-  - KJ_IF_MAYBE
 IncludeBlocks:   Preserve
 IncludeCategories:
   - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
     Priority:        2
     SortPriority:    0
-    CaseSensitive:   false
   - Regex:           '^(<|"(gtest|gmock|isl|json)/)'
     Priority:        3
     SortPriority:    0
-    CaseSensitive:   false
   - Regex:           '.*'
     Priority:        1
     SortPriority:    0
-    CaseSensitive:   false
 IncludeIsMainRegex: '(Test)?$'
 IncludeIsMainSourceRegex: ''
-IndentAccessModifiers: false
-IndentCaseBlocks: false
 IndentCaseLabels: false
-IndentExternBlock: AfterExternBlock
 IndentGotoLabels: true
 IndentPPDirectives: None
-IndentRequiresClause: true
 IndentWidth:     2
 IndentWrappedFunctionNames: false
-InsertBraces:    false
-InsertNewlineAtEOF: false
-InsertTrailingCommas: None
-IntegerLiteralSeparator:
-  Binary:          0
-  BinaryMinDigits: 0
-  Decimal:         0
-  DecimalMinDigits: 0
-  Hex:             0
-  HexMinDigits:    0
 JavaScriptQuotes: Leave
 JavaScriptWrapImports: true
 KeepEmptyLinesAtTheStartOfBlocks: true
-LambdaBodyIndentation: Signature
-LineEnding:      DeriveLF
 MacroBlockBegin: ''
 MacroBlockEnd:   ''
 MaxEmptyLinesToKeep: 1
 NamespaceIndentation: None
 ObjCBinPackProtocolList: Auto
 ObjCBlockIndentWidth: 2
-ObjCBreakBeforeNestedBlockParam: true
 ObjCSpaceAfterProperty: false
 ObjCSpaceBeforeProtocolList: true
-PackConstructorInitializers: BinPack
 PenaltyBreakAssignment: 2
 PenaltyBreakBeforeFirstCallParameter: 19
 PenaltyBreakComment: 300
 PenaltyBreakFirstLessLess: 120
-PenaltyBreakOpenParenthesis: 0
 PenaltyBreakString: 1000
 PenaltyBreakTemplateDeclaration: 10
 PenaltyExcessCharacter: 1000000
-PenaltyIndentedWhitespace: 0
 PenaltyReturnTypeOnItsOwnLine: 60
 PointerAlignment: Right
-PPIndentWidth:   -1
-QualifierAlignment: Leave
-ReferenceAlignment: Pointer
 ReflowComments:  true
-RemoveBracesLLVM: false
-RemoveSemicolon: false
-RequiresClausePosition: OwnLine
-RequiresExpressionIndentation: OuterScope
-SeparateDefinitionBlocks: Leave
-ShortNamespaceLines: 1
-SortIncludes:    CaseSensitive
-SortJavaStaticImport: Before
-SortUsingDeclarations: LexicographicNumeric
+SortIncludes:    true
+SortUsingDeclarations: true
 SpaceAfterCStyleCast: false
 SpaceAfterLogicalNot: false
 SpaceAfterTemplateKeyword: true
-SpaceAroundPointerQualifiers: Default
 SpaceBeforeAssignmentOperators: true
-SpaceBeforeCaseColon: false
 SpaceBeforeCpp11BracedList: false
 SpaceBeforeCtorInitializerColon: true
 SpaceBeforeInheritanceColon: true
 SpaceBeforeParens: ControlStatements
-SpaceBeforeParensOptions:
-  AfterControlStatements: true
-  AfterForeachMacros: true
-  AfterFunctionDefinitionName: false
-  AfterFunctionDeclarationName: false
-  AfterIfMacros:   true
-  AfterOverloadedOperator: false
-  AfterRequiresInClause: false
-  AfterRequiresInExpression: false
-  BeforeNonEmptyParentheses: false
 SpaceBeforeRangeBasedForLoopColon: true
-SpaceBeforeSquareBrackets: false
 SpaceInEmptyBlock: false
 SpaceInEmptyParentheses: false
 SpacesBeforeTrailingComments: 1
-SpacesInAngles:  Never
+SpacesInAngles:  false
 SpacesInConditionalStatement: false
 SpacesInContainerLiterals: true
 SpacesInCStyleCastParentheses: false
-SpacesInLineCommentPrefix:
-  Minimum:         1
-  Maximum:         -1
 SpacesInParentheses: false
 SpacesInSquareBrackets: false
+SpaceBeforeSquareBrackets: false
 Standard:        Latest
-StatementAttributeLikeMacros:
-  - Q_EMIT
 StatementMacros:
   - Q_UNUSED
   - QT_REQUIRE_VERSION
 TabWidth:        8
+UseCRLF:         false
 UseTab:          Never
-WhitespaceSensitiveMacros:
-  - BOOST_PP_STRINGIZE
-  - CF_SWIFT_NAME
-  - NS_SWIFT_NAME
-  - PP_STRINGIZE
-  - STRINGIZE
 ...
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,21 @@
+name: tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  x86_64-linux-gnu-gcc:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.1.1
+        with:
+          fetch-depth: 0
+      - run: cmake -Bbuild
+        env:
+          CC:   gcc-13
+          CXX:  g++-13
+      - run: cmake --build build --parallel --target DCCEXProtocolTests
+      - run: ctest --test-dir build --schedule-random

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,36 +1,28 @@
 cmake_minimum_required(VERSION 3.8)
+include(FetchContent)
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake)
 
-project(DCCEXProtocol)
+project(DCCEXProtocol LANGUAGES CXX)
 
-set(PROJECT_SOURCE_DIR "src")
+file(GLOB_RECURSE SRC src/*.cpp)
+add_library(DCCEXProtocol STATIC ${SRC})
+add_library(DCCEX::Protocol ALIAS DCCEXProtocol)
 
-file(GLOB SOURCE_FILES "${PROJECT_SOURCE_DIR}/*.cpp" "${PROJECT_SOURCE_DIR}/*.h")
+if(NOT TARGET ArduinoCore-API)
+  FetchContent_Declare(
+    ArduinoCore-API
+    GIT_REPOSITORY https://github.com/arduino/ArduinoCore-API
+    GIT_TAG 1.4.0)
+  FetchContent_Populate(ArduinoCore-API)
+  find_package(ArduinoCore-API)
+endif()
 
-foreach(file ${SOURCE_FILES})
-  message(${file})
+target_link_libraries(DCCEXProtocol PUBLIC ArduinoCore-API)
+
+foreach(FILE ${SRC})
+  message(${FILE})
 endforeach()
 
-source_group (TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${SOURCE_FILES})
+source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${SRC})
 
-add_library(DCCEXProtocol ${SOURCE_FILES})
-
-find_package(Doxygen)
-
-if(DOXYGEN_FOUND)
-  message("Found Doxygen")
-  set(DOXYGEN_IN ${CMAKE_CURRENT_SOURCE_DIR}/docs/Doxyfile.in)
-  set(DOXYGEN_OUT ${CMAKE_CURRENT_SOURCE_DIR}/build/Doxyfile.out)
-
-  # request to configure the file
-  configure_file(${DOXYGEN_IN} ${DOXYGEN_OUT} @ONLY)
-  message("Doxygen build started")
-
-  # Note: do not put "ALL" - this builds docs together with application EVERY TIME!
-  add_custom_target( docs
-      COMMAND ${DOXYGEN_EXECUTABLE} ${DOXYGEN_OUT}
-      WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-      COMMENT "Generating API documentation with Doxygen"
-      VERBATIM )
-else (DOXYGEN_FOUND)
-  message("Doxygen need to be installed to generate the doxygen documentation")
-endif(DOXYGEN_FOUND)
+add_subdirectory(docs)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.11 FATAL_ERROR)
 include(FetchContent)
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake)
 
@@ -8,6 +8,17 @@ file(GLOB_RECURSE SRC src/*.cpp)
 add_library(DCCEXProtocol STATIC ${SRC})
 add_library(DCCEX::Protocol ALIAS DCCEXProtocol)
 
+# Requires at least C++11
+target_compile_features(DCCEXProtocol PUBLIC cxx_std_11)
+
+# Don't bother users with warnings by setting 'SYSTEM'
+if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
+  target_include_directories(DCCEXProtocol PUBLIC src)
+else()
+  target_include_directories(DCCEXProtocol SYSTEM PUBLIC src)
+endif()
+
+# Fetch ArduinoCore-API
 if(NOT TARGET ArduinoCore-API)
   FetchContent_Declare(
     ArduinoCore-API
@@ -25,4 +36,13 @@ endforeach()
 
 source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${SRC})
 
-add_subdirectory(docs)
+if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
+  include(CTest)
+  add_subdirectory(docs)
+endif()
+
+if(BUILD_TESTING
+   AND CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME
+   AND CMAKE_SYSTEM_NAME STREQUAL CMAKE_HOST_SYSTEM_NAME)
+  add_subdirectory(tests)
+endif()

--- a/cmake/FindArduinoCore-API.cmake
+++ b/cmake/FindArduinoCore-API.cmake
@@ -1,0 +1,5 @@
+file(GLOB_RECURSE SRC ${arduinocore-api_SOURCE_DIR}/api/*.cpp)
+add_library(ArduinoCore-API STATIC ${SRC})
+target_include_directories(ArduinoCore-API
+                           PUBLIC ${arduinocore-api_SOURCE_DIR}/api)
+target_compile_definitions(ArduinoCore-API PUBLIC -DHOST)

--- a/cmake/FindArduinoCore-API.cmake
+++ b/cmake/FindArduinoCore-API.cmake
@@ -1,5 +1,18 @@
 file(GLOB_RECURSE SRC ${arduinocore-api_SOURCE_DIR}/api/*.cpp)
 add_library(ArduinoCore-API STATIC ${SRC})
-target_include_directories(ArduinoCore-API
-                           PUBLIC ${arduinocore-api_SOURCE_DIR}/api)
+
+# Prevent redeclaration of int atexit(void (*func)())
 target_compile_definitions(ArduinoCore-API PUBLIC -DHOST)
+
+target_include_directories(
+  ArduinoCore-API PUBLIC ${arduinocore-api_BINARY_DIR}
+                         ${arduinocore-api_SOURCE_DIR}/api)
+
+# Create Arduino.h header
+file(
+  WRITE ${arduinocore-api_BINARY_DIR}/Arduino.h #
+  "#ifndef Arduino_h\n" #
+  "#define Arduino_h\n" #
+  "#include \"ArduinoAPI.h\"\n" #
+  "#endif" #
+)

--- a/cmake/sanitize.cmake
+++ b/cmake/sanitize.cmake
@@ -1,0 +1,17 @@
+macro(sanitize SANITIZERS)
+  get_directory_property(HAS_PARENT_SCOPE PARENT_DIRECTORY)
+  if(HAS_PARENT_SCOPE)
+    set(CMAKE_C_FLAGS
+        "${CMAKE_C_FLAGS} -fsanitize=${SANITIZERS}"
+        PARENT_SCOPE)
+    set(CMAKE_CXX_FLAGS
+        "${CMAKE_CXX_FLAGS} -fsanitize=${SANITIZERS}"
+        PARENT_SCOPE)
+    set(LDFLAGS
+        "${LDFLAGS} -fsanitize=${SANITIZERS}"
+        PARENT_SCOPE)
+  endif()
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fsanitize=${SANITIZERS}")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=${SANITIZERS}")
+  set(LDFLAGS "${LDFLAGS} -fsanitize=${SANITIZERS}")
+endmacro()

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -1,0 +1,22 @@
+find_package(Doxygen)
+
+if(DOXYGEN_FOUND)
+  message("Found Doxygen")
+  set(DOXYGEN_IN ${CMAKE_CURRENT_LIST_DIR}/Doxyfile.in)
+  set(DOXYGEN_OUT ${CMAKE_BINARY_DIR}/Doxyfile.out)
+
+  # request to configure the file
+  configure_file(${DOXYGEN_IN} ${DOXYGEN_OUT} @ONLY)
+  message("Doxygen build started")
+
+  # Note: do not put "ALL" - this builds docs together with application EVERY
+  # TIME!
+  add_custom_target(
+    docs
+    COMMAND ${DOXYGEN_EXECUTABLE} ${DOXYGEN_OUT}
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+    COMMENT "Generating API documentation with Doxygen"
+    VERBATIM)
+else()
+  message("Doxygen need to be installed to generate the doxygen documentation")
+endif()

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=DCCEXProtocol
-version=0.0.7
+version=0.0.8
 author=Peter Cole, Peter Akers <akersp62@gmail.com>
 maintainer=Peter Cole, Peter Akers <akersp62@gmail.com>
 sentence=DCC-EX Native Protocol implementation

--- a/src/DCCEXProtocol.h
+++ b/src/DCCEXProtocol.h
@@ -31,8 +31,9 @@
 /*
 Version information:
 
-0.0.7   - add isFunctionMomentary(int function);
-0.0.6   - add getFunctionName(int function);
+0.0.8   - No functional changes, add cross-platform and unit testing capabilities (credit to higaski)
+0.0.7   - Add isFunctionMomentary(int function);
+0.0.6   - Add getFunctionName(int function);
 0.0.5   - Increase MAX_FUNCTIONS to 32. 
         - Also add check to make sure the incoming does not exceed MAX_FUNCTIONS
 0.0.4   - No functional changes, update author/maintainer and URL library properties

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,34 @@
+include(GoogleTest)
+include(${CMAKE_SOURCE_DIR}/cmake/sanitize.cmake)
+
+option(SANITIZE "Enable sanitizers")
+
+file(GLOB_RECURSE SRC *.cpp)
+add_executable(DCCEXProtocolTests ${SRC})
+
+# Reuse ArduinoCore-API fakes and mocks
+target_sources(
+  DCCEXProtocolTests
+  PRIVATE ${arduinocore-api_SOURCE_DIR}/test/src/MillisFake.cpp
+          ${arduinocore-api_SOURCE_DIR}/test/src/PrintMock.cpp
+          ${arduinocore-api_SOURCE_DIR}/test/src/StreamMock.cpp)
+target_include_directories(DCCEXProtocolTests
+                           PUBLIC ${arduinocore-api_SOURCE_DIR}/test/include)
+
+if(SANITIZE)
+  sanitize(address,undefined)
+endif()
+
+target_compile_options(DCCEXProtocolTests PUBLIC -Wall -Wextra -Wconversion
+                                                 -Wsign-conversion)
+
+FetchContent_Declare(
+  googletest
+  GIT_REPOSITORY https://github.com/google/googletest.git
+  GIT_TAG main)
+FetchContent_MakeAvailable(googletest)
+
+target_link_libraries(DCCEXProtocolTests PRIVATE DCCEXProtocol
+                                                 GTest::gtest_main GTest::gmock)
+
+gtest_discover_tests(DCCEXProtocolTests)

--- a/tests/DCCEXProtocolDelegateMock.hpp
+++ b/tests/DCCEXProtocolDelegateMock.hpp
@@ -1,0 +1,39 @@
+#include <DCCEXProtocol.h>
+#include <gmock/gmock.h>
+
+class DCCEXProtocolDelegateMock : public DCCEXProtocolDelegate {
+public:
+  // Notify when the server version has been received
+  MOCK_METHOD(void, receivedServerVersion, (int, int, int), (override));
+
+  // Notify when the roster list is received
+  MOCK_METHOD(void, receivedRosterList, (), (override));
+
+  // Notify when the turnout list is received
+  MOCK_METHOD(void, receivedTurnoutList, (), (override));
+
+  // Notify when the route list is received
+  MOCK_METHOD(void, receivedRouteList, (), (override));
+
+  // Notify when the turntable list is received
+  MOCK_METHOD(void, receivedTurntableList, (), (override));
+
+  // Notify when an update to a Loco object is received
+  MOCK_METHOD(void, receivedLocoUpdate, (Loco *), (override));
+
+  // Notify when a track power state change is received
+  MOCK_METHOD(void, receivedTrackPower, (TrackPower), (override));
+
+  // Notify when a track type change is received
+  MOCK_METHOD(void, receivedTrackType, (char, TrackManagerMode, int),
+              (override));
+
+  // Notify when a turnout state change is received
+  MOCK_METHOD(void, receivedTurnoutAction, (int, bool), (override));
+
+  // Notify when a turntable index change is received
+  MOCK_METHOD(void, receivedTurntableAction, (int, int, bool), (override));
+
+  // Notify when a loco address is read from the programming track
+  MOCK_METHOD(void, receivedReadLoco, (int), (override));
+};

--- a/tests/DCCEXProtocolTest.cpp
+++ b/tests/DCCEXProtocolTest.cpp
@@ -1,0 +1,9 @@
+#include "DCCEXProtocolTest.hpp"
+
+// Set delegate and stream
+DCCEXProtocolTest::DCCEXProtocolTest() {
+  _dccexProtocol.setDelegate(&_delegate);
+  _dccexProtocol.connect(&_stream);
+}
+
+DCCEXProtocolTest::~DCCEXProtocolTest() {}

--- a/tests/DCCEXProtocolTest.hpp
+++ b/tests/DCCEXProtocolTest.hpp
@@ -1,0 +1,17 @@
+#include "DCCEXProtocolDelegateMock.hpp"
+#include <DCCEXProtocol.h>
+#include <StreamMock.h>
+
+using namespace testing;
+
+// DCCEXProtocol test fixture
+class DCCEXProtocolTest : public Test {
+public:
+  DCCEXProtocolTest();
+  virtual ~DCCEXProtocolTest();
+
+protected:
+  DCCEXProtocol _dccexProtocol;
+  DCCEXProtocolDelegateMock _delegate;
+  StreamMock _stream;
+};

--- a/tests/TrackPower.cpp
+++ b/tests/TrackPower.cpp
@@ -1,0 +1,15 @@
+#include "DCCEXProtocolTest.hpp"
+
+TEST_F(DCCEXProtocolTest, allTracksOff) {
+  _stream << "<p0>";
+  EXPECT_CALL(_delegate, receivedTrackPower(TrackPower::PowerOff))
+      .Times(Exactly(1));
+  _dccexProtocol.check();
+}
+
+TEST_F(DCCEXProtocolTest, allTracksOn) {
+  _stream << "<p1>";
+  EXPECT_CALL(_delegate, receivedTrackPower(TrackPower::PowerOn))
+      .Times(Exactly(1));
+  _dccexProtocol.check();
+}

--- a/tests/Version.cpp
+++ b/tests/Version.cpp
@@ -1,0 +1,7 @@
+#include "DCCEXProtocolTest.hpp"
+
+TEST_F(DCCEXProtocolTest, version) {
+  _stream << "<iDCCEX V-1.2.3 / MEGA / STANDARD_MOTOR_SHIELD / 7>";
+  EXPECT_CALL(_delegate, receivedServerVersion(1, 2, 3)).Times(Exactly(1));
+  _dccexProtocol.check();
+}


### PR DESCRIPTION
This PR introduces rudimentary CMake support for non-Arduino targets. The CMakeLists.txt file creates a static library target called DCCEXProtocol (aliased as DCCEX::Protocol).

~~To get this to work the hardware independent [ArduinoCore-API](https://github.com/arduino/ArduinoCore-API) gets included as dependency. I've removed direct dependencies to the `<Arduino.h>` header (which isn't available in the Core-API) in all files and instead included the necessary interfaces (e.g. `Stream.h`, `Print.h`, ...).~~

The ArduinoCore-API has no CMake support so a `Find<PackageName>.cmake` file had to be written. A common convention is to place such files in a cmake subfolder.

With those changes in place the DCCEXProtocol library can be compiled on any platform.