### PR TITLE
Clear buffer when full

### DIFF
--- a/src/DCCEXProtocol.cpp
+++ b/src/DCCEXProtocol.cpp
@@ -96,6 +96,10 @@ void DCCEXProtocol::check() {
         _cmdBuffer[_bufflen] = r;
         _bufflen++;
         _cmdBuffer[_bufflen] = 0;
+      } else {
+        // Clear buffer if full
+        _cmdBuffer[0] = 0;
+        _bufflen = 0;
       }
 
       if (r == '>') {

--- a/tests/DCCEXProtocol.cpp
+++ b/tests/DCCEXProtocol.cpp
@@ -1,0 +1,12 @@
+#include "DCCEXProtocolTest.hpp"
+
+TEST_F(DCCEXProtocolTest, clearBufferWhenFull) {
+  // Fill buffer with garbage
+  for (auto i{0uz}; i < 500uz; ++i)
+    _stream.write(static_cast<uint8_t>('A' + (random() % 26)));
+
+  // Proceed with normal message
+  _stream << R"(<m "Hello World">)";
+  EXPECT_CALL(_delegate, receivedMessage(StrEq("Hello World"))).Times(Exactly(1));
+  _dccexProtocol.check();
+}


### PR DESCRIPTION
Clearing the receive buffer when it's full prevents it from ever becoming clogged.