### PR TITLE
Fix x86 tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,8 +14,5 @@ jobs:
         with:
           fetch-depth: 0
       - run: cmake -Bbuild
-        env:
-          CC:   gcc-13
-          CXX:  g++-13
       - run: cmake --build build --parallel --target DCCEXProtocolTests
       - run: ./build/tests/DCCEXProtocolTests --gtest_shuffle


### PR DESCRIPTION
Fix x86 tests now that ubuntu-latest defaults to ubuntu 24.04