### PR TITLE
Fast clock, currents

### DIFF
--- a/src/DCCEXProtocolVersion.h
+++ b/src/DCCEXProtocolVersion.h
@@ -71,6 +71,19 @@ Version information:
                 - setMomentum(Loco *loco, int accelerating, int braking)
         - Add method to enable/disable debug output to console, default is off (false)
                 - setDebug(bool debug)
+        - Add support for fast clock with new delegate methods:
+                - setFastClock(int minutes, int speedFactor)
+                - requestFastClockTime()
+                - receivedSetFastClock(int minutes, int speedFactor)
+                - receivedFastClockTime(int minutes)
+        - Add support for track gauges (current limits) and track current:
+                - requestTrackCurrentGauges()
+                - requestTrackCurrents()
+                - receivedTrackCurrentGauge(char track, int limit)
+                - receivedTrackCurrent(char track, int current)
+        - Fix compiler warnings by change char * to const char * in these methods:
+                - sendCommand(const char *cmd)
+                - receivedScreenUpdate(int screen, int row, const char *message)
 1.2.1   - Refactor Consist::addLoco to use itoa instead of snprintf for Flash savings
         - Refactor all DCCEXProtocol outbound commands to remove sprintf
         - Add default true to getLists() so users can just call it without parameters to get all lists

--- a/test/mocks/MockDCCEXProtocolDelegate.h
+++ b/test/mocks/MockDCCEXProtocolDelegate.h
@@ -7,7 +7,7 @@ public:
   MOCK_METHOD(void, receivedServerVersion, (int, int, int), (override));
 
   // Notify when a broadcast message has been received
-  MOCK_METHOD(void, receivedMessage, (char *), (override));
+  MOCK_METHOD(void, receivedMessage, (const char *), (override));
 
   // Notify when the roster list is received
   MOCK_METHOD(void, receivedRosterList, (), (override));
@@ -29,6 +29,12 @@ public:
 
   // Notify when a track power state change is received
   MOCK_METHOD(void, receivedTrackPower, (TrackPower), (override));
+
+  // Notify when a track current gauge is received
+  MOCK_METHOD(void, receivedTrackCurrentGauge, (char track, int limit), (override));
+
+  // Notify when a track current is received
+  MOCK_METHOD(void, receivedTrackCurrent, (char track, int current), (override));
 
   // Notify when a track type change is received
   MOCK_METHOD(void, receivedTrackType, (char, TrackManagerMode, int), (override));
@@ -54,6 +60,15 @@ public:
   // Notify when a loco address is written on the programming track
   MOCK_METHOD(void, receivedWriteLoco, (int), (override));
 
+  // Notify when a screen update has been received
+  MOCK_METHOD(void, receivedScreenUpdate, (int screen, int row, const char *message), (override));
+
   // Notify when a CSConsist has been received
   MOCK_METHOD(void, receivedCSConsist, (int, CSConsist *), (override));
+
+  // Notify when set fast clock has been received
+  MOCK_METHOD(void, receivedSetFastClock, (int minutes, int speedFactor), (override));
+
+  // Notify when a fast clock time has been received
+  MOCK_METHOD(void, receivedFastClockTime, (int minutes), (override));
 };

--- a/test/test_General/test_CurrentGauges.cpp
+++ b/test/test_General/test_CurrentGauges.cpp
@@ -1,0 +1,123 @@
+/* -*- c++ -*-
+ *
+ * Copyright © 2026 Peter Cole
+ *
+ * This work is licensed under the Creative Commons Attribution-ShareAlike
+ * 4.0 International License. To view a copy of this license, visit
+ * http://creativecommons.org/licenses/by-sa/4.0/ or send a letter to
+ * Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.
+ *
+ * Attribution — You must give appropriate credit, provide a link to the
+ * license, and indicate if changes were made. You may do so in any
+ * reasonable manner, but not in any way that suggests the licensor
+ * endorses you or your use.
+ *
+ * ShareAlike — If you remix, transform, or build upon the material, you
+ * must distribute your contributions under the same license as the
+ * original.
+ *
+ * All other rights reserved.
+ *
+ */
+
+#include "../setup/DCCEXProtocolTests.h"
+
+/**
+ * @brief Test requesting gauge limits for one track
+ */
+TEST_F(DCCEXProtocolTests, TestRequestGaugeLimitsOneTrack) {
+  // Send <J G>
+  _dccexProtocol.requestTrackCurrentGauges();
+  EXPECT_EQ(_stream.getOutput(), "<J G>");
+
+  // Simulate response <jG 1499> - A
+  EXPECT_CALL(_delegate, receivedTrackCurrentGauge('A', 1499)).Times(1);
+  _stream << "<jG 1499>";
+  _dccexProtocol.check();
+}
+
+/**
+ * @brief Test requesting gauge limits for default two tracks
+ */
+TEST_F(DCCEXProtocolTests, TestRequestGaugeLimitsTwoTracks) {
+  // Send <J G>
+  _dccexProtocol.requestTrackCurrentGauges();
+  EXPECT_EQ(_stream.getOutput(), "<J G>");
+
+  // Simulate response <jG 1499 1499> - A B
+  EXPECT_CALL(_delegate, receivedTrackCurrentGauge('A', 1499)).Times(1);
+  EXPECT_CALL(_delegate, receivedTrackCurrentGauge('B', 1499)).Times(1);
+  _stream << "<jG 1499 1499>";
+  _dccexProtocol.check();
+}
+
+/**
+ * @brief Test requesting gauge limits for max 8 tracks
+ */
+TEST_F(DCCEXProtocolTests, TestRequestGaugeLimitsEightTracks) {
+  // Send <J G>
+  _dccexProtocol.requestTrackCurrentGauges();
+  EXPECT_EQ(_stream.getOutput(), "<J G>");
+
+  // Simulate response <jG 1499 1499 1499 1499 1499 1499 1499 1499> - A B C D E F G H
+  EXPECT_CALL(_delegate, receivedTrackCurrentGauge('A', 1499)).Times(1);
+  EXPECT_CALL(_delegate, receivedTrackCurrentGauge('B', 1499)).Times(1);
+  EXPECT_CALL(_delegate, receivedTrackCurrentGauge('C', 1499)).Times(1);
+  EXPECT_CALL(_delegate, receivedTrackCurrentGauge('D', 1499)).Times(1);
+  EXPECT_CALL(_delegate, receivedTrackCurrentGauge('E', 1499)).Times(1);
+  EXPECT_CALL(_delegate, receivedTrackCurrentGauge('F', 1499)).Times(1);
+  EXPECT_CALL(_delegate, receivedTrackCurrentGauge('G', 1499)).Times(1);
+  EXPECT_CALL(_delegate, receivedTrackCurrentGauge('H', 1499)).Times(1);
+  _stream << "<jG 1499 1499 1499 1499 1499 1499 1499 1499>";
+  _dccexProtocol.check();
+}
+
+/**
+ * @brief Test requesting current for one track
+ */
+TEST_F(DCCEXProtocolTests, TestRequestCurrentOneTrack) {
+  // Send <J I>
+  _dccexProtocol.requestTrackCurrents();
+  EXPECT_EQ(_stream.getOutput(), "<J I>");
+
+  // Simulate response <jI 500> - A
+  EXPECT_CALL(_delegate, receivedTrackCurrent('A', 500)).Times(1);
+  _stream << "<jI 500>";
+  _dccexProtocol.check();
+}
+
+/**
+ * @brief Test requesting current for default two tracks
+ */
+TEST_F(DCCEXProtocolTests, TestRequestCurrentTwoTracks) {
+  // Send <J I>
+  _dccexProtocol.requestTrackCurrents();
+  EXPECT_EQ(_stream.getOutput(), "<J I>");
+
+  // Simulate response <jI 500 0> - A B
+  EXPECT_CALL(_delegate, receivedTrackCurrent('A', 500)).Times(1);
+  EXPECT_CALL(_delegate, receivedTrackCurrent('B', 0)).Times(1);
+  _stream << "<jI 500 0>";
+  _dccexProtocol.check();
+}
+
+/**
+ * @brief Test requesting current for max 8 tracks
+ */
+TEST_F(DCCEXProtocolTests, TestRequestCurrentEightTracks) {
+  // Send <J I>
+  _dccexProtocol.requestTrackCurrents();
+  EXPECT_EQ(_stream.getOutput(), "<J I>");
+
+  // Simulate response <jI 1200 895 124 50 0 0 0 1300> - A B C D E F G H
+  EXPECT_CALL(_delegate, receivedTrackCurrent('A', 1200)).Times(1);
+  EXPECT_CALL(_delegate, receivedTrackCurrent('B', 895)).Times(1);
+  EXPECT_CALL(_delegate, receivedTrackCurrent('C', 124)).Times(1);
+  EXPECT_CALL(_delegate, receivedTrackCurrent('D', 50)).Times(1);
+  EXPECT_CALL(_delegate, receivedTrackCurrent('E', 0)).Times(1);
+  EXPECT_CALL(_delegate, receivedTrackCurrent('F', 0)).Times(1);
+  EXPECT_CALL(_delegate, receivedTrackCurrent('G', 0)).Times(1);
+  EXPECT_CALL(_delegate, receivedTrackCurrent('H', 1300)).Times(1);
+  _stream << "<jI 1200 895 124 50 0 0 0 1300>";
+  _dccexProtocol.check();
+}

--- a/test/test_General/test_FastClock.cpp
+++ b/test/test_General/test_FastClock.cpp
@@ -1,0 +1,69 @@
+/* -*- c++ -*-
+ *
+ * Copyright © 2026 Peter Cole
+ *
+ * This work is licensed under the Creative Commons Attribution-ShareAlike
+ * 4.0 International License. To view a copy of this license, visit
+ * http://creativecommons.org/licenses/by-sa/4.0/ or send a letter to
+ * Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.
+ *
+ * Attribution — You must give appropriate credit, provide a link to the
+ * license, and indicate if changes were made. You may do so in any
+ * reasonable manner, but not in any way that suggests the licensor
+ * endorses you or your use.
+ *
+ * ShareAlike — If you remix, transform, or build upon the material, you
+ * must distribute your contributions under the same license as the
+ * original.
+ *
+ * All other rights reserved.
+ *
+ */
+
+#include "../setup/DCCEXProtocolTests.h"
+
+/**
+ * @brief Test setting the fast clock
+ */
+TEST_F(DCCEXProtocolTests, TestSetFastClock) {
+  // Send <J C 60 4> - 1am 4, times speed
+  _dccexProtocol.setFastClock(60, 4);
+  EXPECT_EQ(_stream.getOutput(), "<J C 60 4>");
+
+  // Simulate response <jC 60 4>
+  EXPECT_CALL(_delegate, receivedSetFastClock(60, 4));
+  // Also screen update <@ 0 6 "Time 01:00 (4)">
+  EXPECT_CALL(_delegate, receivedScreenUpdate(0, 6, StrEq("Time 01:00 (4)")));
+
+  _stream << "<jC 60 4>";
+  _stream << "<@ 0 6 \"Time 01:00 (4)\">";
+  _dccexProtocol.check();
+}
+
+/**
+ * @brief Test requesting the fast clock time
+ */
+TEST_F(DCCEXProtocolTests, TestRequestFastClockTime) {
+  // Send <J C>
+  _dccexProtocol.requestFastClockTime();
+  EXPECT_EQ(_stream.getOutput(), "<J C>");
+
+  // Simulate response <jC 60>
+  _stream << "<jC 60>";
+  EXPECT_CALL(_delegate, receivedFastClockTime(60));
+  _dccexProtocol.check();
+}
+
+/**
+ * @brief Test setting fast clock time/speed with invalid values
+ */
+TEST_F(DCCEXProtocolTests, TestInvalidFastClockTimeAndSpeed) {
+  _dccexProtocol.setFastClock(0, 0);
+  EXPECT_EQ(_stream.getOutput(), "");
+  _dccexProtocol.setFastClock(0, -1);
+  EXPECT_EQ(_stream.getOutput(), "");
+  _dccexProtocol.setFastClock(-1, 4);
+  EXPECT_EQ(_stream.getOutput(), "");
+  _dccexProtocol.setFastClock(2000, 4);
+  EXPECT_EQ(_stream.getOutput(), "");
+}

--- a/test/test_Loco/test_Consist.cpp
+++ b/test/test_Loco/test_Consist.cpp
@@ -26,7 +26,7 @@
 /// @brief Create a consist with three Loco objects
 TEST_F(LocoTests, createConsistByLoco) {
   // Create three locos for the consist
-  char *functionList = "Lights/*Horn";
+  const char *functionList = "Lights/*Horn";
   Loco *loco10 = new Loco(10, LocoSourceRoster);
   loco10->setName("Loco 10");
   loco10->setupFunctions(functionList);

--- a/test/test_NoDelegate/test_NoDelegate.cpp
+++ b/test/test_NoDelegate/test_NoDelegate.cpp
@@ -225,3 +225,37 @@ TEST_F(TestHarnessNoDelegate, TestTurntableBroadcast) {
   _stream << "<I 1 1 0>";
   _dccexProtocol.check();
 }
+
+/**
+ * @brief Test receiving track current gauges does not seg fault
+ */
+TEST_F(TestHarnessNoDelegate, TestReceivingCurrentGauge) {
+  // Simulate receiving track current gauge does not trigger seg fault
+  _stream << "<jG 1499 1499>";
+  _dccexProtocol.check();
+}
+
+/**
+ * @brief Test receiving track currents does not seg fault
+ */
+TEST_F(TestHarnessNoDelegate, TestReceivingCurrent) {
+  // Simulate receiving track currents does not trigger seg fault
+  _stream << "<jI 600 200>";
+  _dccexProtocol.check();
+}
+
+/**
+ * @brief Test receiving set fast clock does not seg fault
+ */
+TEST_F(TestHarnessNoDelegate, TestReceivingSetFastClock) {
+  _stream << "<jC 60 4>";
+  _dccexProtocol.check();
+}
+
+/**
+ * @brief Test receiving fast clock time does not seg fault
+ */
+TEST_F(TestHarnessNoDelegate, TestReceivingFastClockTime) {
+  _stream << "<jC 60>";
+  _dccexProtocol.check();
+}


### PR DESCRIPTION
Add support for fast clock with new delegate methods:
- setFastClock(int minutes, int speedFactor)
- requestFastClockTime()
- receivedSetFastClock(int minutes, int speedFactor)
- receivedFastClockTime(int minutes)

Add support for track gauges (current limits) and track current:
- requestTrackCurrentGauges()
- requestTrackCurrents()
- receivedTrackCurrentGauge(char track, int limit)
- receivedTrackCurrent(char track, int current)

Fix compiler warnings by change char * to const char * in these methods:
- sendCommand(const char *cmd)
- receivedScreenUpdate(int screen, int row, const char *message)