### PR TITLE
Redo of changes to allow other compiler setups to Arduino - eg ESP-IDF

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ test_coverage/
 .cache/
 build/
 build-*/
+config.h

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,8 @@ _build
 # Coverage info file
 lcov.info
 test_coverage/
+
+# cmake cache.
+.cache/
+build/
+build-*/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,13 +2,12 @@ cmake_minimum_required(VERSION 3.11)
 
 # Detect ESP-IDF build
 if(ESP_PLATFORM OR DEFINED ENV{IDF_PATH})
-    file(GLOB_RECURSE SRC src/*.cpp)
-    set(COMPONENT_SRCS ${SRC}) # Add all your source files here
-    set(COMPONENT_ADD_INCLUDEDIRS src)
-    set(COMPONENT_PRIV_INCLUDEDIRS "")
-    set(COMPONENT_REQUIRES esp_timer)
-    set(COMPONENT_PRIV_REQUIRES "")
-    register_component()
+  file(GLOB_RECURSE SRC src/*.cpp)
+  idf_component_register(
+    SRCS ${SRC}
+    INCLUDE_DIRS src
+    REQUIRES esp_timer
+  )
 else()
     include(FetchContent)
     list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ if(ESP_PLATFORM OR DEFINED ENV{IDF_PATH})
     set(COMPONENT_SRCS ${SRC}) # Add all your source files here
     set(COMPONENT_ADD_INCLUDEDIRS src)
     set(COMPONENT_PRIV_INCLUDEDIRS "")
-  set(COMPONENT_REQUIRES esp_timer)
+    set(COMPONENT_REQUIRES esp_timer)
     set(COMPONENT_PRIV_REQUIRES "")
     register_component()
 else()
@@ -15,7 +15,7 @@ else()
 
     project(DCCEXProtocol LANGUAGES CXX)
 
-  option(DCCEX_BUILD_TESTS "Build native GoogleTest test target" ON)
+    option(DCCEX_BUILD_TESTS "Build native GoogleTest test target" ON)
 
     file(GLOB_RECURSE SRC src/*.cpp)
     add_library(DCCEXProtocol STATIC ${SRC})
@@ -38,12 +38,12 @@ else()
     source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${SRC})
 
     if(DCCEX_BUILD_TESTS)
-      include(CTest)
       enable_testing()
 
       FetchContent_Declare(
         googletest
         URL https://github.com/google/googletest/archive/refs/tags/v1.17.0.zip
+        DOWNLOAD_EXTRACT_TIMESTAMP true
       )
       FetchContent_MakeAvailable(googletest)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,68 @@
+cmake_minimum_required(VERSION 3.11)
+
+# Detect ESP-IDF build
+if(ESP_PLATFORM OR DEFINED ENV{IDF_PATH})
+    file(GLOB_RECURSE SRC src/*.cpp)
+    set(COMPONENT_SRCS ${SRC}) # Add all your source files here
+    set(COMPONENT_ADD_INCLUDEDIRS src)
+    set(COMPONENT_PRIV_INCLUDEDIRS "")
+  set(COMPONENT_REQUIRES esp_timer)
+    set(COMPONENT_PRIV_REQUIRES "")
+    register_component()
+else()
+    include(FetchContent)
+    list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake)
+
+    project(DCCEXProtocol LANGUAGES CXX)
+
+  option(DCCEX_BUILD_TESTS "Build native GoogleTest test target" ON)
+
+    file(GLOB_RECURSE SRC src/*.cpp)
+    add_library(DCCEXProtocol STATIC ${SRC})
+    add_library(DCCEX::Protocol ALIAS DCCEXProtocol)
+
+    # Stuck at C++11
+    target_compile_options(DCCEXProtocol PRIVATE -std=c++11)
+
+    # Don't bother users with warnings by setting 'SYSTEM'
+    if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
+      target_include_directories(DCCEXProtocol PUBLIC src)
+    else()
+      target_include_directories(DCCEXProtocol SYSTEM PUBLIC src)
+    endif()
+
+    foreach(FILE ${SRC})
+      message(${FILE})
+    endforeach()
+
+    source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${SRC})
+
+    if(DCCEX_BUILD_TESTS)
+      include(CTest)
+      enable_testing()
+
+      FetchContent_Declare(
+        googletest
+        URL https://github.com/google/googletest/archive/refs/tags/v1.17.0.zip
+      )
+      FetchContent_MakeAvailable(googletest)
+
+      file(GLOB_RECURSE TEST_SOURCES CONFIGURE_DEPENDS test/*.cpp)
+      add_executable(DCCEXProtocolTests ${TEST_SOURCES})
+
+      target_compile_definitions(DCCEXProtocolTests PRIVATE NATIVE_TESTING)
+      target_include_directories(DCCEXProtocolTests PRIVATE test/mocks test/setup)
+      target_link_libraries(DCCEXProtocolTests PRIVATE DCCEXProtocol GTest::gtest GTest::gmock)
+
+      include(GoogleTest)
+      gtest_discover_tests(DCCEXProtocolTests)
+
+      add_custom_target(check
+        COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure
+        DEPENDS DCCEXProtocolTests
+        USES_TERMINAL
+      )
+
+      add_custom_target(run-tests DEPENDS check)
+    endif()
+endif()

--- a/README.md
+++ b/README.md
@@ -18,6 +18,33 @@ The implementation of this library is tested on ESP32 based devices running the 
 
 There has also been limited testing on STM32F103C8 Bluepill.
 
+## Cross-platform millis support
+
+The library now uses a platform-neutral time macro internally. By default it uses Arduino millis(), and it can be overridden for non-Arduino targets without changing library source code.
+
+Built-in defaults are provided in src/DCCMillisWrappers.h for:
+
+- Arduino (millis)
+- ESP-IDF (esp_timer_get_time()/1000)
+- Pico SDK (to_ms_since_boot(get_absolute_time()))
+
+If your target is not covered, define DCCEX_MILLIS() in your build flags or before including DCCEXProtocol.h.
+
+Examples:
+
+- Arduino: no change required.
+- ESP-IDF:
+
+   add_compile_definitions(DCCEX_MILLIS()=dccex_esp_idf_millis())
+
+- Pico SDK:
+
+   add_compile_definitions(DCCEX_MILLIS()=dccex_pico_millis())
+
+- Custom platform function:
+
+   -DDCCEX_MILLIS()=my_platform_millis()
+
 ## Basic Design Principles
 
 First of all, this library implements the DCC-EX Native protocol in a non-blocking fashion. After creating a DCCEXProtocol object, you set up various necessities such as the network connection and a debug console (see [Dependency Injection][depinj]).

--- a/examples/DCCEXProtocol_Basic/platformio.ini
+++ b/examples/DCCEXProtocol_Basic/platformio.ini
@@ -1,0 +1,24 @@
+; PlatformIO config for the DCCEXProtocol Basic example
+;
+; Usage from this folder:
+;   pio run
+;   pio run -t upload
+;   pio device monitor
+
+[platformio]
+default_envs = esp32dev
+src_dir = .
+
+[env:esp32dev]
+platform = espressif32
+framework = arduino
+board = esp32dev
+
+; Pick your serial port if auto-detection does not work
+; upload_port = /dev/ttyUSB0
+
+monitor_speed = 115200
+upload_speed = 921600
+
+; Make the library in the repository root available to this example
+lib_extra_dirs = ../../

--- a/examples/DCCEXProtocol_CSConsist_Control/platformio.ini
+++ b/examples/DCCEXProtocol_CSConsist_Control/platformio.ini
@@ -1,0 +1,24 @@
+; PlatformIO config for the DCCEXProtocol Basic example
+;
+; Usage from this folder:
+;   pio run
+;   pio run -t upload
+;   pio device monitor
+
+[platformio]
+default_envs = esp32dev
+src_dir = .
+
+[env:esp32dev]
+platform = espressif32
+framework = arduino
+board = esp32dev
+
+; Pick your serial port if auto-detection does not work
+; upload_port = /dev/ttyUSB0
+
+monitor_speed = 115200
+upload_speed = 921600
+
+; Make the library in the repository root available to this example
+lib_extra_dirs = ../../

--- a/examples/DCCEXProtocol_Consist_Control/platformio.ini
+++ b/examples/DCCEXProtocol_Consist_Control/platformio.ini
@@ -1,0 +1,24 @@
+; PlatformIO config for the DCCEXProtocol Basic example
+;
+; Usage from this folder:
+;   pio run
+;   pio run -t upload
+;   pio device monitor
+
+[platformio]
+default_envs = esp32dev
+src_dir = .
+
+[env:esp32dev]
+platform = espressif32
+framework = arduino
+board = esp32dev
+
+; Pick your serial port if auto-detection does not work
+; upload_port = /dev/ttyUSB0
+
+monitor_speed = 115200
+upload_speed = 921600
+
+; Make the library in the repository root available to this example
+lib_extra_dirs = ../../

--- a/examples/DCCEXProtocol_Delegate/platformio.ini
+++ b/examples/DCCEXProtocol_Delegate/platformio.ini
@@ -1,0 +1,24 @@
+; PlatformIO config for the DCCEXProtocol Basic example
+;
+; Usage from this folder:
+;   pio run
+;   pio run -t upload
+;   pio device monitor
+
+[platformio]
+default_envs = esp32dev
+src_dir = .
+
+[env:esp32dev]
+platform = espressif32
+framework = arduino
+board = esp32dev
+
+; Pick your serial port if auto-detection does not work
+; upload_port = /dev/ttyUSB0
+
+monitor_speed = 115200
+upload_speed = 921600
+
+; Make the library in the repository root available to this example
+lib_extra_dirs = ../../

--- a/examples/DCCEXProtocol_Loco_Control/platformio.ini
+++ b/examples/DCCEXProtocol_Loco_Control/platformio.ini
@@ -1,0 +1,24 @@
+; PlatformIO config for the DCCEXProtocol Basic example
+;
+; Usage from this folder:
+;   pio run
+;   pio run -t upload
+;   pio device monitor
+
+[platformio]
+default_envs = esp32dev
+src_dir = .
+
+[env:esp32dev]
+platform = espressif32
+framework = arduino
+board = esp32dev
+
+; Pick your serial port if auto-detection does not work
+; upload_port = /dev/ttyUSB0
+
+monitor_speed = 115200
+upload_speed = 921600
+
+; Make the library in the repository root available to this example
+lib_extra_dirs = ../../

--- a/examples/DCCEXProtocol_Multi_Throttle_Control/platformio.ini
+++ b/examples/DCCEXProtocol_Multi_Throttle_Control/platformio.ini
@@ -1,0 +1,24 @@
+; PlatformIO config for the DCCEXProtocol Basic example
+;
+; Usage from this folder:
+;   pio run
+;   pio run -t upload
+;   pio device monitor
+
+[platformio]
+default_envs = esp32dev
+src_dir = .
+
+[env:esp32dev]
+platform = espressif32
+framework = arduino
+board = esp32dev
+
+; Pick your serial port if auto-detection does not work
+; upload_port = /dev/ttyUSB0
+
+monitor_speed = 115200
+upload_speed = 921600
+
+; Make the library in the repository root available to this example
+lib_extra_dirs = ../../

--- a/examples/DCCEXProtocol_Roster_etc/platformio.ini
+++ b/examples/DCCEXProtocol_Roster_etc/platformio.ini
@@ -1,0 +1,24 @@
+; PlatformIO config for the DCCEXProtocol Basic example
+;
+; Usage from this folder:
+;   pio run
+;   pio run -t upload
+;   pio device monitor
+
+[platformio]
+default_envs = esp32dev
+src_dir = .
+
+[env:esp32dev]
+platform = espressif32
+framework = arduino
+board = esp32dev
+
+; Pick your serial port if auto-detection does not work
+; upload_port = /dev/ttyUSB0
+
+monitor_speed = 115200
+upload_speed = 921600
+
+; Make the library in the repository root available to this example
+lib_extra_dirs = ../../

--- a/examples/DCCEXProtocol_SSID/platformio.ini
+++ b/examples/DCCEXProtocol_SSID/platformio.ini
@@ -1,0 +1,24 @@
+; PlatformIO config for the DCCEXProtocol Basic example
+;
+; Usage from this folder:
+;   pio run
+;   pio run -t upload
+;   pio device monitor
+
+[platformio]
+default_envs = esp32dev
+src_dir = .
+
+[env:esp32dev]
+platform = espressif32
+framework = arduino
+board = esp32dev
+
+; Pick your serial port if auto-detection does not work
+; upload_port = /dev/ttyUSB0
+
+monitor_speed = 115200
+upload_speed = 921600
+
+; Make the library in the repository root available to this example
+lib_extra_dirs = ../../

--- a/examples/DCCEXProtocol_Serial/platformio.ini
+++ b/examples/DCCEXProtocol_Serial/platformio.ini
@@ -1,0 +1,24 @@
+; PlatformIO config for the DCCEXProtocol Basic example
+;
+; Usage from this folder:
+;   pio run
+;   pio run -t upload
+;   pio device monitor
+
+[platformio]
+default_envs = esp32dev
+src_dir = .
+
+[env:esp32dev]
+platform = espressif32
+framework = arduino
+board = esp32dev
+
+; Pick your serial port if auto-detection does not work
+; upload_port = /dev/ttyUSB0
+
+monitor_speed = 115200
+upload_speed = 921600
+
+; Make the library in the repository root available to this example
+lib_extra_dirs = ../../

--- a/examples/DCCEXProtocol_Track_type/platformio.ini
+++ b/examples/DCCEXProtocol_Track_type/platformio.ini
@@ -1,0 +1,24 @@
+; PlatformIO config for the DCCEXProtocol Basic example
+;
+; Usage from this folder:
+;   pio run
+;   pio run -t upload
+;   pio device monitor
+
+[platformio]
+default_envs = esp32dev
+src_dir = .
+
+[env:esp32dev]
+platform = espressif32
+framework = arduino
+board = esp32dev
+
+; Pick your serial port if auto-detection does not work
+; upload_port = /dev/ttyUSB0
+
+monitor_speed = 115200
+upload_speed = 921600
+
+; Make the library in the repository root available to this example
+lib_extra_dirs = ../../

--- a/examples/DCCEXProtocol_Turnout_Control/platformio.ini
+++ b/examples/DCCEXProtocol_Turnout_Control/platformio.ini
@@ -1,0 +1,24 @@
+; PlatformIO config for the DCCEXProtocol Basic example
+;
+; Usage from this folder:
+;   pio run
+;   pio run -t upload
+;   pio device monitor
+
+[platformio]
+default_envs = esp32dev
+src_dir = .
+
+[env:esp32dev]
+platform = espressif32
+framework = arduino
+board = esp32dev
+
+; Pick your serial port if auto-detection does not work
+; upload_port = /dev/ttyUSB0
+
+monitor_speed = 115200
+upload_speed = 921600
+
+; Make the library in the repository root available to this example
+lib_extra_dirs = ../../

--- a/examples/DCCEXProtocol_mDNS/platformio.ini
+++ b/examples/DCCEXProtocol_mDNS/platformio.ini
@@ -1,0 +1,24 @@
+; PlatformIO config for the DCCEXProtocol Basic example
+;
+; Usage from this folder:
+;   pio run
+;   pio run -t upload
+;   pio device monitor
+
+[platformio]
+default_envs = esp32dev
+src_dir = .
+
+[env:esp32dev]
+platform = espressif32
+framework = arduino
+board = esp32dev
+
+; Pick your serial port if auto-detection does not work
+; upload_port = /dev/ttyUSB0
+
+monitor_speed = 115200
+upload_speed = 921600
+
+; Make the library in the repository root available to this example
+lib_extra_dirs = ../../

--- a/examples/ESP-IDF/CMakeLists.txt
+++ b/examples/ESP-IDF/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.16)
+
+set(EXTRA_COMPONENT_DIRS
+  "${CMAKE_CURRENT_LIST_DIR}/../.."
+)
+
+include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+project(DCCEXProtocolExamples)

--- a/examples/ESP-IDF/README.md
+++ b/examples/ESP-IDF/README.md
@@ -1,0 +1,21 @@
+# ESP-IDF Examples
+
+This directory contains a standalone ESP-IDF project for DCCEXProtocol examples.
+
+## Layout
+
+- `main/` contains the application entry point.
+- `DCCEXProtocol_Basic/` contains the first example as its own ESP-IDF component.
+- Additional ESP-IDF examples should be added as sibling component directories beside `DCCEXProtocol_Basic/`.
+
+## Build
+
+From this directory, run:
+
+```sh
+idf.py set-target esp32
+idf.py build
+idf.py flash monitor
+```
+
+The project consumes the local library from the repository root via `EXTRA_COMPONENT_DIRS`, so changes to the main DCCEXProtocol source are picked up directly.

--- a/examples/ESP-IDF/dependencies.lock
+++ b/examples/ESP-IDF/dependencies.lock
@@ -1,0 +1,17 @@
+dependencies:
+  DCCEXProtocol:
+    dependencies: []
+    source:
+      path: ../..
+      type: local
+    version: 2.3.3
+  idf:
+    source:
+      type: idf
+    version: 6.0.1
+direct_dependencies:
+- DCCEXProtocol
+- idf
+manifest_hash: 98e7dfa278ee0bd8b8c3054e443f523dc69076aaa0b357437701fd978486f272
+target: esp32
+version: 3.0.0

--- a/examples/ESP-IDF/main/CMakeLists.txt
+++ b/examples/ESP-IDF/main/CMakeLists.txt
@@ -1,0 +1,20 @@
+set(SOURCE_FILES "")
+file(GLOB_RECURSE SOURCE_FILES 
+  "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp"
+)
+
+idf_component_register(
+  SRCS 
+    ${SOURCE_FILES}
+  
+  PRIV_REQUIRES 
+    esp_event 
+    lwip
+    esp_wifi 
+    nvs_flash
+    spi_flash
+    esp_netif
+    DCCEXProtocol
+  INCLUDE_DIRS
+    "."
+)

--- a/examples/ESP-IDF/main/config.example.h
+++ b/examples/ESP-IDF/main/config.example.h
@@ -1,0 +1,7 @@
+// Example user configuration to use with the DCCEXProtocol examples
+// Copy this file and rename to config.h
+// Replace the variables below with the appropriate values for your environment
+const char *ssid = "YOUR_SSID_HERE";         // WiFi SSID name here
+const char *password = "YOUR_PASSWORD_HERE"; // WiFi password here
+const char *serverAddress = "192.168.4.1";   // IP address of your EX-CommandStation
+int serverPort = 2560;                       // Network port of your EX-CommandStation

--- a/examples/ESP-IDF/main/config.h
+++ b/examples/ESP-IDF/main/config.h
@@ -1,7 +1,0 @@
-// Example user configuration to use with the DCCEXProtocol examples
-// Copy this file and rename to config.h
-// Replace the variables below with the appropriate values for your environment
-const char *ssid = "WINTERS";         // WiFi SSID name here
-const char *password = "tesskatt"; // WiFi password here
-const char *serverAddress = "192.168.1.6";   // IP address of your EX-CommandStation
-int serverPort = 2560;                       // Network port of your EX-CommandStation

--- a/examples/ESP-IDF/main/config.h
+++ b/examples/ESP-IDF/main/config.h
@@ -1,0 +1,7 @@
+// Example user configuration to use with the DCCEXProtocol examples
+// Copy this file and rename to config.h
+// Replace the variables below with the appropriate values for your environment
+const char *ssid = "WINTERS";         // WiFi SSID name here
+const char *password = "tesskatt"; // WiFi password here
+const char *serverAddress = "192.168.1.6";   // IP address of your EX-CommandStation
+int serverPort = 2560;                       // Network port of your EX-CommandStation

--- a/examples/ESP-IDF/main/idf_component.yml
+++ b/examples/ESP-IDF/main/idf_component.yml
@@ -1,0 +1,10 @@
+## IDF Component Manager Manifest File
+dependencies:
+  ## Required IDF version
+  idf:
+    version: '>=5.5.1'
+  DCCEXProtocol:
+    path: ../../../DCCEXProtocol
+    # git: https://github.com/mwinters-stuff/DCCEXProtocol.git
+    # version: main
+

--- a/examples/ESP-IDF/main/loco_control.cpp
+++ b/examples/ESP-IDF/main/loco_control.cpp
@@ -1,0 +1,333 @@
+#include "loco_control.h"
+
+#include "../../../src/DCCEXProtocol.h"
+
+#include <cstdarg>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+
+#include <esp_event.h>
+#include <esp_log.h>
+#include <esp_netif.h>
+#include <esp_system.h>
+#include <esp_wifi.h>
+#include <freertos/event_groups.h>
+#include <lwip/netdb.h>
+#include <lwip/sockets.h>
+#include <nvs_flash.h>
+
+#if __has_include("config.h")
+#include "config.h"
+#else
+#error config.h not found. Copy from config.example.h and update with your settings.
+#endif
+
+namespace {
+
+constexpr const char *TAG = "DCCEXBasic";
+
+class EspLogStream : public Stream {
+public:
+  int available() override { return 0; }
+
+  int read() override { return -1; }
+
+  size_t write(const uint8_t *buffer, size_t size) override {
+    if (buffer == nullptr || size == 0) {
+      return 0;
+    }
+
+    char message[128];
+    const size_t copy_length = size < sizeof(message) - 1 ? size : sizeof(message) - 1;
+    memcpy(message, buffer, copy_length);
+    message[copy_length] = '\0';
+    printf("[%s] %s\n", TAG, message);
+    return size;
+  }
+
+  void flush() override {}
+
+  void println(const char *format, ...) override {
+    if (format == nullptr) {
+      return;
+    }
+
+    va_list args;
+    va_start(args, format);
+    vlog(format, args);
+    va_end(args);
+  }
+
+  void print(const char *format, ...) override {
+    if (format == nullptr) {
+      return;
+    }
+
+    va_list args;
+    va_start(args, format);
+    vlog(format, args);
+    va_end(args);
+  }
+
+private:
+  static void vlog(const char *format, va_list args) {
+    char message[192];
+    vsnprintf(message, sizeof(message), format, args);
+    printf("[%s] %s\n", TAG, message);
+  }
+};
+
+// ---------------------------------------------------------------------------
+// TcpStream — wraps a connected lwIP socket as a DCCEXProtocol Stream
+// ---------------------------------------------------------------------------
+class TcpStream : public Stream {
+public:
+  explicit TcpStream(int fd) : _fd(fd) {}
+
+  int available() override {
+    int count = 0;
+    if (ioctl(_fd, FIONREAD, &count) < 0) {
+      return 0;
+    }
+    return count;
+  }
+
+  int read() override {
+    uint8_t byte = 0;
+    const int n = recv(_fd, &byte, 1, 0);
+    return (n == 1) ? static_cast<int>(byte) : -1;
+  }
+
+  size_t write(const uint8_t *buffer, size_t size) override {
+    if (buffer == nullptr || size == 0) {
+      return 0;
+    }
+    const ssize_t n = send(_fd, buffer, size, 0);
+    return (n < 0) ? 0 : static_cast<size_t>(n);
+  }
+
+  void flush() override {}
+
+private:
+  int _fd;
+};
+
+// for random speed changes
+int speed = 0;
+int up = 1;
+unsigned long lastTime = 0;
+
+// define our loco object
+Loco *loco = nullptr;
+
+// Global objects
+EspLogStream log_stream;
+DCCEXProtocol dccexProtocol;
+bool started = false;
+int dcc_sock = -1;
+TcpStream *dcc_stream = nullptr;
+
+constexpr int WIFI_CONNECTED_BIT = BIT0;
+constexpr int WIFI_FAIL_BIT      = BIT1;
+constexpr int WIFI_MAX_RETRY     = 5;
+
+EventGroupHandle_t s_wifi_event_group;
+int s_retry_count = 0;
+
+static void wifi_event_handler(void *arg, esp_event_base_t event_base,
+                               int32_t event_id, void *event_data) {
+  if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_STA_START) {
+    esp_wifi_connect();
+  } else if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_STA_DISCONNECTED) {
+    if (s_retry_count < WIFI_MAX_RETRY) {
+      esp_wifi_connect();
+      ++s_retry_count;
+      printf("[%s] Retrying WiFi connection (%d/%d)\n", TAG, s_retry_count, WIFI_MAX_RETRY);
+    } else {
+      xEventGroupSetBits(s_wifi_event_group, WIFI_FAIL_BIT);
+      printf("[%s] WiFi connection failed\n", TAG);
+    }
+  } else if (event_base == IP_EVENT && event_id == IP_EVENT_STA_GOT_IP) {
+    ip_event_got_ip_t *event = static_cast<ip_event_got_ip_t *>(event_data);
+    printf("[%s] WiFi connected, IP: " IPSTR "\n", TAG, IP2STR(&event->ip_info.ip));
+    s_retry_count = 0;
+    xEventGroupSetBits(s_wifi_event_group, WIFI_CONNECTED_BIT);
+  }
+}
+
+class MyDelegate : public DCCEXProtocolDelegate {
+
+public:
+  void receivedServerVersion(int major, int minor, int patch) override {
+    printf("[%s] Received version: %d.%d.%d\n", TAG, major, minor, patch);
+  }
+
+    void receivedTrackPower(TrackPower state) override {
+    printf("[%s] Received Track Power: %d\n", TAG, static_cast<int>(state));
+  }
+
+  // Use for roster Locos (LocoSource::LocoSourceRoster)
+  void receivedLocoUpdate(Loco *loco) override {
+    printf("[%s] Received Loco update for DCC address: %d\n", TAG, loco->getAddress());
+  }
+
+  // Use for locally created Locos (LocoSource::LocoSourceEntry)
+  void receivedLocoBroadcast(int address, int speed, Direction direction, int functionMap) override {
+    printf("[%s] Received Loco broadcast: address|speed|direction|functionMap: %d|%d|%s|%d\n", TAG, address, speed, (direction == Direction::Forward ? "Fwd" : "Rev"), functionMap);
+  }
+};
+
+
+} // namespace
+
+bool connect_dcc() {
+  char port_str[8];
+  snprintf(port_str, sizeof(port_str), "%d", serverPort);
+
+  addrinfo hints = {};
+  hints.ai_family   = AF_INET;
+  hints.ai_socktype = SOCK_STREAM;
+
+  addrinfo *res = nullptr;
+  if (getaddrinfo(serverAddress, port_str, &hints, &res) != 0 || res == nullptr) {
+    printf("[DCCEXBasic] DNS lookup failed for %s\n", serverAddress);
+    return false;
+  }
+
+  dcc_sock = socket(res->ai_family, res->ai_socktype, res->ai_protocol);
+  if (dcc_sock < 0) {
+    freeaddrinfo(res);
+    printf("[DCCEXBasic] Failed to create socket\n");
+    return false;
+  }
+
+  if (::connect(dcc_sock, res->ai_addr, res->ai_addrlen) != 0) {
+    freeaddrinfo(res);
+    close(dcc_sock);
+    dcc_sock = -1;
+    printf("[DCCEXBasic] TCP connect to %s:%d failed\n", serverAddress, serverPort);
+    return false;
+  }
+
+  freeaddrinfo(res);
+
+  dcc_stream = new TcpStream(dcc_sock);
+  dccexProtocol.connect(dcc_stream);
+  printf("[DCCEXBasic] Connected to DCC-EX at %s:%d\n", serverAddress, serverPort);
+  return true;
+}
+
+bool connect_wifi() {
+  esp_err_t ret = nvs_flash_init();
+  if (ret == ESP_ERR_NVS_NO_FREE_PAGES || ret == ESP_ERR_NVS_NEW_VERSION_FOUND) {
+    ESP_ERROR_CHECK(nvs_flash_erase());
+    ret = nvs_flash_init();
+  }
+  ESP_ERROR_CHECK(ret);
+
+  s_wifi_event_group = xEventGroupCreate();
+
+  ESP_ERROR_CHECK(esp_netif_init());
+  ESP_ERROR_CHECK(esp_event_loop_create_default());
+  esp_netif_create_default_wifi_sta();
+
+  wifi_init_config_t cfg = WIFI_INIT_CONFIG_DEFAULT();
+  ESP_ERROR_CHECK(esp_wifi_init(&cfg));
+
+  esp_event_handler_instance_t instance_any_id;
+  esp_event_handler_instance_t instance_got_ip;
+  ESP_ERROR_CHECK(esp_event_handler_instance_register(WIFI_EVENT, ESP_EVENT_ANY_ID,
+                                                      &wifi_event_handler, nullptr,
+                                                      &instance_any_id));
+  ESP_ERROR_CHECK(esp_event_handler_instance_register(IP_EVENT, IP_EVENT_STA_GOT_IP,
+                                                      &wifi_event_handler, nullptr,
+                                                      &instance_got_ip));
+
+  wifi_config_t wifi_config = {};
+  strncpy(reinterpret_cast<char *>(wifi_config.sta.ssid), ssid,
+          sizeof(wifi_config.sta.ssid) - 1);
+  strncpy(reinterpret_cast<char *>(wifi_config.sta.password), password,
+          sizeof(wifi_config.sta.password) - 1);
+
+  ESP_ERROR_CHECK(esp_wifi_set_mode(WIFI_MODE_STA));
+  ESP_ERROR_CHECK(esp_wifi_set_config(WIFI_IF_STA, &wifi_config));
+  ESP_ERROR_CHECK(esp_wifi_start());
+
+  EventBits_t bits = xEventGroupWaitBits(s_wifi_event_group,
+                                         WIFI_CONNECTED_BIT | WIFI_FAIL_BIT,
+                                         pdFALSE, pdFALSE, portMAX_DELAY);
+
+  esp_event_handler_instance_unregister(IP_EVENT, IP_EVENT_STA_GOT_IP, instance_got_ip);
+  esp_event_handler_instance_unregister(WIFI_EVENT, ESP_EVENT_ANY_ID, instance_any_id);
+  vEventGroupDelete(s_wifi_event_group);
+
+  return (bits & WIFI_CONNECTED_BIT) != 0;
+}
+
+void dccex_basic_example_start() {
+  dccexProtocol.setLogStream(&log_stream);
+  dccexProtocol.enableHeartbeat();
+  dccexProtocol.setDelegate(new MyDelegate());
+  dccexProtocol.setDebug(true);
+
+  if (!connect_wifi()) {
+    printf("[%s] WiFi failed — cannot continue\n", TAG);
+    return;
+  }
+
+  if (!connect_dcc()) {
+    printf("[%s] DCC-EX connect failed — cannot continue\n", TAG);
+    return;
+  }
+
+  printf("[%s] DCC-EX ready\n", TAG);
+  started = true;
+
+  dccexProtocol.requestServerVersion();
+  // protocol.getLists();
+
+  lastTime = esp_timer_get_time() / 1000; // current time in ms
+}
+
+void dccex_basic_example_tick() {
+  if (!started) {
+    return;
+  }
+
+  dccexProtocol.check();
+
+   if (!loco) {
+    // add a loco with DCC address 11 - LocoSourceEntry means it's not from the roster
+    loco = new Loco(11, LocoSource::LocoSourceEntry);
+    printf("[%s] Added loco: %d\n", TAG, loco->getAddress());
+
+    // turn track power on or the loco won't move
+    dccexProtocol.powerOn();
+  }
+
+  if (loco) {
+    // every 10 seconds change speed and set a random function on or off
+    if ((esp_timer_get_time() / 1000 - lastTime) >= 10000) {
+      if (speed >= 100)
+        up = -1;
+      if (speed <= 0)
+        up = 1;
+      speed = speed + up;
+      dccexProtocol.setThrottle(loco, speed, Direction::Forward);
+
+      int fn = static_cast<int>(esp_random() % 27);
+      int fns = static_cast<int>(esp_random() % 100);
+      bool fnState = (fns < 50) ? false : true;
+
+      if (fnState) {
+        dccexProtocol.functionOn(loco, fn);
+      } else {
+        dccexProtocol.functionOff(loco, fn);
+      }
+
+      lastTime = esp_timer_get_time() / 1000; // current time in ms
+    }
+  }
+}
+

--- a/examples/ESP-IDF/main/loco_control.h
+++ b/examples/ESP-IDF/main/loco_control.h
@@ -1,0 +1,9 @@
+#ifndef DCCEX_LOCO_CONTROL_H
+#define DCCEX_LOCO_CONTROL_H
+
+bool connect_wifi();
+bool connect_dcc();
+void dccex_basic_example_start();
+void dccex_basic_example_tick();
+
+#endif

--- a/examples/ESP-IDF/main/main.cpp
+++ b/examples/ESP-IDF/main/main.cpp
@@ -1,0 +1,13 @@
+#include "loco_control.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+
+extern "C" void app_main(void) {
+  dccex_basic_example_start();
+
+
+  while (true) {
+    dccex_basic_example_tick();
+    vTaskDelay(10 / portTICK_PERIOD_MS); // Delay for 10 milliseconds
+  }
+}

--- a/examples/ESP-IDF/sdkconfig
+++ b/examples/ESP-IDF/sdkconfig
@@ -1,0 +1,3467 @@
+#
+# Automatically generated file. DO NOT EDIT.
+# Espressif IoT Development Framework (ESP-IDF) 6.0.1 Project Configuration
+#
+# default:
+CONFIG_SOC_CAPS_ECO_VER_MAX=301
+# default:
+CONFIG_SOC_ADC_SUPPORTED=y
+# default:
+CONFIG_SOC_DAC_SUPPORTED=y
+# default:
+CONFIG_SOC_UART_SUPPORTED=y
+# default:
+CONFIG_SOC_MCPWM_SUPPORTED=y
+# default:
+CONFIG_SOC_GPTIMER_SUPPORTED=y
+# default:
+CONFIG_SOC_SDMMC_HOST_SUPPORTED=y
+# default:
+CONFIG_SOC_BT_SUPPORTED=y
+# default:
+CONFIG_SOC_PCNT_SUPPORTED=y
+# default:
+CONFIG_SOC_PHY_SUPPORTED=y
+# default:
+CONFIG_SOC_WIFI_SUPPORTED=y
+# default:
+CONFIG_SOC_SDIO_SLAVE_SUPPORTED=y
+# default:
+CONFIG_SOC_TWAI_SUPPORTED=y
+# default:
+CONFIG_SOC_EFUSE_SUPPORTED=y
+# default:
+CONFIG_SOC_EMAC_SUPPORTED=y
+# default:
+CONFIG_SOC_ULP_SUPPORTED=y
+# default:
+CONFIG_SOC_CCOMP_TIMER_SUPPORTED=y
+# default:
+CONFIG_SOC_RTC_FAST_MEM_SUPPORTED=y
+# default:
+CONFIG_SOC_RTC_SLOW_MEM_SUPPORTED=y
+# default:
+CONFIG_SOC_RTC_MEM_SUPPORTED=y
+# default:
+CONFIG_SOC_RTC_TIMER_V1_SUPPORTED=y
+# default:
+CONFIG_SOC_I2S_SUPPORTED=y
+# default:
+CONFIG_SOC_I2S_I80_LCD_SUPPORTED=y
+# default:
+CONFIG_SOC_LCD_I80_SUPPORTED=y
+# default:
+CONFIG_SOC_RMT_SUPPORTED=y
+# default:
+CONFIG_SOC_SDM_SUPPORTED=y
+# default:
+CONFIG_SOC_GPSPI_SUPPORTED=y
+# default:
+CONFIG_SOC_LEDC_SUPPORTED=y
+# default:
+CONFIG_SOC_I2C_SUPPORTED=y
+# default:
+CONFIG_SOC_SUPPORT_COEXISTENCE=y
+# default:
+CONFIG_SOC_AES_SUPPORTED=y
+# default:
+CONFIG_SOC_MPI_SUPPORTED=y
+# default:
+CONFIG_SOC_SHA_SUPPORTED=y
+# default:
+CONFIG_SOC_FLASH_ENC_SUPPORTED=y
+# default:
+CONFIG_SOC_SECURE_BOOT_SUPPORTED=y
+# default:
+CONFIG_SOC_TOUCH_SENSOR_SUPPORTED=y
+# default:
+CONFIG_SOC_BOD_SUPPORTED=y
+# default:
+CONFIG_SOC_ULP_FSM_SUPPORTED=y
+# default:
+CONFIG_SOC_CLK_TREE_SUPPORTED=y
+# default:
+CONFIG_SOC_MPU_SUPPORTED=y
+# default:
+CONFIG_SOC_WDT_SUPPORTED=y
+# default:
+CONFIG_SOC_SPI_FLASH_SUPPORTED=y
+# default:
+CONFIG_SOC_RNG_SUPPORTED=y
+# default:
+CONFIG_SOC_LIGHT_SLEEP_SUPPORTED=y
+# default:
+CONFIG_SOC_DEEP_SLEEP_SUPPORTED=y
+# default:
+CONFIG_SOC_LP_PERIPH_SHARE_INTERRUPT=y
+# default:
+CONFIG_SOC_PM_SUPPORTED=y
+# default:
+CONFIG_SOC_DPORT_WORKAROUND_DIS_INTERRUPT_LVL=5
+# default:
+CONFIG_SOC_XTAL_SUPPORT_26M=y
+# default:
+CONFIG_SOC_XTAL_SUPPORT_40M=y
+# default:
+CONFIG_SOC_ADC_RTC_CTRL_SUPPORTED=y
+# default:
+CONFIG_SOC_ADC_DIG_CTRL_SUPPORTED=y
+# default:
+CONFIG_SOC_ADC_DMA_SUPPORTED=y
+# default:
+CONFIG_SOC_ADC_PERIPH_NUM=2
+# default:
+CONFIG_SOC_ADC_MAX_CHANNEL_NUM=10
+# default:
+CONFIG_SOC_ADC_ATTEN_NUM=4
+# default:
+CONFIG_SOC_ADC_DIGI_CONTROLLER_NUM=2
+# default:
+CONFIG_SOC_ADC_PATT_LEN_MAX=16
+# default:
+CONFIG_SOC_ADC_DIGI_MIN_BITWIDTH=9
+# default:
+CONFIG_SOC_ADC_DIGI_MAX_BITWIDTH=12
+# default:
+CONFIG_SOC_ADC_DIGI_RESULT_BYTES=2
+# default:
+CONFIG_SOC_ADC_DIGI_DATA_BYTES_PER_CONV=4
+# default:
+CONFIG_SOC_ADC_DIGI_MONITOR_NUM=0
+# default:
+CONFIG_SOC_ADC_SAMPLE_FREQ_THRES_HIGH=2000000
+# default:
+CONFIG_SOC_ADC_SAMPLE_FREQ_THRES_LOW=20000
+# default:
+CONFIG_SOC_ADC_RTC_MIN_BITWIDTH=9
+# default:
+CONFIG_SOC_ADC_RTC_MAX_BITWIDTH=12
+# default:
+CONFIG_SOC_ADC_SHARED_POWER=y
+# default:
+CONFIG_SOC_BROWNOUT_RESET_SUPPORTED=y
+# default:
+CONFIG_SOC_SHARED_IDCACHE_SUPPORTED=y
+# default:
+CONFIG_SOC_IDCACHE_PER_CORE=y
+# default:
+CONFIG_SOC_CPU_CORES_NUM=2
+# default:
+CONFIG_SOC_CPU_INTR_NUM=32
+# default:
+CONFIG_SOC_CPU_HAS_FPU=y
+# default:
+CONFIG_SOC_HP_CPU_HAS_MULTIPLE_CORES=y
+# default:
+CONFIG_SOC_CPU_BREAKPOINTS_NUM=2
+# default:
+CONFIG_SOC_CPU_WATCHPOINTS_NUM=2
+# default:
+CONFIG_SOC_CPU_WATCHPOINT_MAX_REGION_SIZE=0x40
+# default:
+CONFIG_SOC_DAC_CHAN_NUM=2
+# default:
+CONFIG_SOC_DAC_RESOLUTION=8
+# default:
+CONFIG_SOC_DAC_DMA_16BIT_ALIGN=y
+# default:
+CONFIG_SOC_GPIO_PORT=1
+# default:
+CONFIG_SOC_GPIO_PIN_COUNT=40
+# default:
+CONFIG_SOC_GPIO_VALID_GPIO_MASK=0xFFFFFFFFFF
+# default:
+CONFIG_SOC_GPIO_IN_RANGE_MAX=39
+# default:
+CONFIG_SOC_GPIO_OUT_RANGE_MAX=33
+# default:
+CONFIG_SOC_GPIO_VALID_DIGITAL_IO_PAD_MASK=0xEF0FEA
+# default:
+CONFIG_SOC_GPIO_CLOCKOUT_BY_IO_MUX=y
+# default:
+CONFIG_SOC_GPIO_CLOCKOUT_CHANNEL_NUM=3
+# default:
+CONFIG_SOC_I2C_NUM=2
+# default:
+CONFIG_SOC_HP_I2C_NUM=2
+# default:
+CONFIG_SOC_I2C_SUPPORT_APB=y
+# default:
+CONFIG_SOC_I2C_SUPPORT_10BIT_ADDR=y
+# default:
+CONFIG_SOC_I2C_SUPPORT_SLAVE=y
+# default:
+CONFIG_SOC_I2C_STOP_INDEPENDENT=y
+# default:
+CONFIG_SOC_I2S_HW_VERSION_1=y
+# default:
+CONFIG_SOC_I2S_SUPPORTS_APLL=y
+# default:
+CONFIG_SOC_I2S_SUPPORTS_PDM=y
+# default:
+CONFIG_SOC_I2S_SUPPORTS_PDM_TX=y
+# default:
+CONFIG_SOC_I2S_SUPPORTS_PCM2PDM=y
+# default:
+CONFIG_SOC_I2S_SUPPORTS_PDM_RX=y
+# default:
+CONFIG_SOC_I2S_SUPPORTS_PDM2PCM=y
+# default:
+CONFIG_SOC_I2S_PDM_MAX_TX_LINES=1
+# default:
+CONFIG_SOC_I2S_PDM_MAX_RX_LINES=1
+# default:
+CONFIG_SOC_LEDC_HAS_TIMER_SPECIFIC_MUX=y
+# default:
+CONFIG_SOC_LEDC_SUPPORT_APB_CLOCK=y
+# default:
+CONFIG_SOC_LEDC_SUPPORT_REF_TICK=y
+# default:
+CONFIG_SOC_LEDC_SUPPORT_HS_MODE=y
+# default:
+CONFIG_SOC_LEDC_TIMER_NUM=4
+# default:
+CONFIG_SOC_LEDC_CHANNEL_NUM=8
+# default:
+CONFIG_SOC_LEDC_TIMER_BIT_WIDTH=20
+# default:
+CONFIG_SOC_MMU_PERIPH_NUM=2
+# default:
+CONFIG_SOC_MMU_LINEAR_ADDRESS_REGION_NUM=3
+# default:
+CONFIG_SOC_MPU_MIN_REGION_SIZE=0x20000000
+# default:
+CONFIG_SOC_MPU_REGIONS_MAX_NUM=8
+# default:
+CONFIG_SOC_RMT_MEM_WORDS_PER_CHANNEL=64
+# default:
+CONFIG_SOC_RTCIO_PIN_COUNT=18
+# default:
+CONFIG_SOC_RTCIO_INPUT_OUTPUT_SUPPORTED=y
+# default:
+CONFIG_SOC_RTCIO_HOLD_SUPPORTED=y
+# default:
+CONFIG_SOC_RTCIO_WAKE_SUPPORTED=y
+# default:
+CONFIG_SOC_RTC_CNTL_NEEDS_ATOMIC_ACCESS=y
+# default:
+CONFIG_SOC_SPI_HD_BOTH_INOUT_SUPPORTED=y
+# default:
+CONFIG_SOC_SPI_AS_CS_SUPPORTED=y
+# default:
+CONFIG_SOC_SPI_PERIPH_NUM=3
+# default:
+CONFIG_SOC_SPI_DMA_CHAN_NUM=2
+# default:
+CONFIG_SOC_SPI_MAX_CS_NUM=3
+# default:
+CONFIG_SOC_SPI_SUPPORT_CLK_APB=y
+# default:
+CONFIG_SOC_SPI_MAXIMUM_BUFFER_SIZE=64
+# default:
+CONFIG_SOC_SPI_MAX_PRE_DIVIDER=8192
+# default:
+CONFIG_SOC_MEMSPI_ENCRYPTION_ALIGNMENT=16
+# default:
+CONFIG_SOC_LP_TIMER_BIT_WIDTH_LO=32
+# default:
+CONFIG_SOC_LP_TIMER_BIT_WIDTH_HI=16
+# default:
+CONFIG_SOC_TOUCH_SENSOR_VERSION=1
+# default:
+CONFIG_SOC_TOUCH_MIN_CHAN_ID=0
+# default:
+CONFIG_SOC_TOUCH_MAX_CHAN_ID=9
+# default:
+CONFIG_SOC_TOUCH_SUPPORT_SLEEP_WAKEUP=y
+# default:
+CONFIG_SOC_TOUCH_SAMPLE_CFG_NUM=1
+# default:
+CONFIG_SOC_TWAI_CONTROLLER_NUM=1
+# default:
+CONFIG_SOC_TWAI_MASK_FILTER_NUM=1
+# default:
+CONFIG_SOC_UART_NUM=3
+# default:
+CONFIG_SOC_UART_HP_NUM=3
+# default:
+CONFIG_SOC_UART_SUPPORT_APB_CLK=y
+# default:
+CONFIG_SOC_UART_SUPPORT_REF_TICK=y
+# default:
+CONFIG_SOC_UART_FIFO_LEN=128
+# default:
+CONFIG_SOC_UART_BITRATE_MAX=5000000
+# default:
+CONFIG_SOC_UART_WAKEUP_SUPPORT_ACTIVE_THRESH_MODE=y
+# default:
+CONFIG_SOC_SPIRAM_SUPPORTED=y
+# default:
+CONFIG_SOC_SPI_MEM_SUPPORT_CONFIG_GPIO_BY_EFUSE=y
+# default:
+CONFIG_SOC_SHA_SUPPORT_PARALLEL_ENG=y
+# default:
+CONFIG_SOC_SHA_ENDIANNESS_BE=y
+# default:
+CONFIG_SOC_SHA_SUPPORT_SHA1=y
+# default:
+CONFIG_SOC_SHA_SUPPORT_SHA256=y
+# default:
+CONFIG_SOC_SHA_SUPPORT_SHA384=y
+# default:
+CONFIG_SOC_SHA_SUPPORT_SHA512=y
+# default:
+CONFIG_SOC_MPI_MEM_BLOCKS_NUM=4
+# default:
+CONFIG_SOC_MPI_OPERATIONS_NUM=1
+# default:
+CONFIG_SOC_RSA_MAX_BIT_LEN=4096
+# default:
+CONFIG_SOC_AES_SUPPORT_AES_128=y
+# default:
+CONFIG_SOC_AES_SUPPORT_AES_192=y
+# default:
+CONFIG_SOC_AES_SUPPORT_AES_256=y
+# default:
+CONFIG_SOC_SECURE_BOOT_V1=y
+# default:
+CONFIG_SOC_EFUSE_SECURE_BOOT_KEY_DIGESTS=1
+# default:
+CONFIG_SOC_FLASH_ENCRYPTED_XTS_AES_BLOCK_MAX=32
+# default:
+CONFIG_SOC_PHY_DIG_REGS_MEM_SIZE=21
+# default:
+CONFIG_SOC_PM_SUPPORT_EXT0_WAKEUP=y
+# default:
+CONFIG_SOC_PM_SUPPORT_EXT1_WAKEUP=y
+# default:
+CONFIG_SOC_PM_SUPPORT_EXT_WAKEUP=y
+# default:
+CONFIG_SOC_PM_SUPPORT_TOUCH_SENSOR_WAKEUP=y
+# default:
+CONFIG_SOC_PM_SUPPORT_RTC_PERIPH_PD=y
+# default:
+CONFIG_SOC_PM_SUPPORT_RTC_FAST_MEM_PD=y
+# default:
+CONFIG_SOC_PM_SUPPORT_RTC_SLOW_MEM_PD=y
+# default:
+CONFIG_SOC_PM_SUPPORT_RC_FAST_PD=y
+# default:
+CONFIG_SOC_PM_SUPPORT_VDDSDIO_PD=y
+# default:
+CONFIG_SOC_PM_SUPPORT_MODEM_PD=y
+# default:
+CONFIG_SOC_CONFIGURABLE_VDDSDIO_SUPPORTED=y
+# default:
+CONFIG_SOC_PM_MODEM_PD_BY_SW=y
+# default:
+CONFIG_SOC_CLK_APLL_SUPPORTED=y
+# default:
+CONFIG_SOC_CLK_RC_FAST_D256_SUPPORTED=y
+# default:
+CONFIG_SOC_RTC_SLOW_CLK_SUPPORT_RC_FAST_D256=y
+# default:
+CONFIG_SOC_CLK_RC_FAST_SUPPORT_CALIBRATION=y
+# default:
+CONFIG_SOC_CLK_XTAL32K_SUPPORTED=y
+# default:
+CONFIG_SOC_CLK_LP_FAST_SUPPORT_XTAL_D4=y
+# default:
+CONFIG_SOC_SDMMC_USE_IOMUX=y
+# default:
+CONFIG_SOC_SDMMC_NUM_SLOTS=2
+# default:
+CONFIG_SOC_SDMMC_DATA_WIDTH_MAX=8
+# default:
+CONFIG_SOC_WIFI_WAPI_SUPPORT=y
+# default:
+CONFIG_SOC_WIFI_CSI_SUPPORT=y
+# default:
+CONFIG_SOC_WIFI_MESH_SUPPORT=y
+# default:
+CONFIG_SOC_WIFI_SUPPORT_VARIABLE_BEACON_WINDOW=y
+# default:
+CONFIG_SOC_WIFI_NAN_SUPPORT=y
+# default:
+CONFIG_SOC_BLE_SUPPORTED=y
+# default:
+CONFIG_SOC_BLE_MESH_SUPPORTED=y
+# default:
+CONFIG_SOC_BT_CLASSIC_SUPPORTED=y
+# default:
+CONFIG_SOC_BLUFI_SUPPORTED=y
+# default:
+CONFIG_SOC_BT_H2C_ENC_KEY_CTRL_ENH_VSC_SUPPORTED=y
+# default:
+CONFIG_SOC_BLE_MULTI_CONN_OPTIMIZATION=y
+# default:
+CONFIG_SOC_ULP_HAS_ADC=y
+# default:
+CONFIG_SOC_PHY_COMBO_MODULE=y
+# default:
+CONFIG_SOC_EMAC_RMII_CLK_OUT_INTERNAL_LOOPBACK=y
+# default:
+CONFIG_IDF_CMAKE=y
+# default:
+CONFIG_IDF_TOOLCHAIN="gcc"
+# default:
+CONFIG_IDF_TOOLCHAIN_GCC=y
+# default:
+CONFIG_IDF_TARGET_ARCH_XTENSA=y
+# default:
+CONFIG_IDF_TARGET_ARCH="xtensa"
+# default:
+CONFIG_IDF_TARGET="esp32"
+# default:
+CONFIG_IDF_INIT_VERSION="6.0.1"
+# default:
+CONFIG_IDF_TARGET_ESP32=y
+# default:
+CONFIG_IDF_FIRMWARE_CHIP_ID=0x0000
+
+#
+# Build type
+#
+# default:
+CONFIG_APP_BUILD_TYPE_APP_2NDBOOT=y
+# default:
+# CONFIG_APP_BUILD_TYPE_RAM is not set
+# default:
+CONFIG_APP_BUILD_GENERATE_BINARIES=y
+# default:
+CONFIG_APP_BUILD_BOOTLOADER=y
+# default:
+CONFIG_APP_BUILD_USE_FLASH_SECTIONS=y
+# default:
+# CONFIG_APP_REPRODUCIBLE_BUILD is not set
+# default:
+# CONFIG_APP_NO_BLOBS is not set
+# default:
+# CONFIG_APP_COMPATIBLE_PRE_V2_1_BOOTLOADERS is not set
+# default:
+# CONFIG_APP_COMPATIBLE_PRE_V3_1_BOOTLOADERS is not set
+# end of Build type
+
+#
+# App Update config
+#
+# end of App Update config
+
+#
+# Bootloader config
+#
+
+#
+# Bootloader manager
+#
+# default:
+CONFIG_BOOTLOADER_COMPILE_TIME_DATE=y
+# default:
+CONFIG_BOOTLOADER_PROJECT_VER=1
+# end of Bootloader manager
+
+#
+# Application Rollback
+#
+# default:
+# CONFIG_BOOTLOADER_APP_ROLLBACK_ENABLE is not set
+# end of Application Rollback
+
+#
+# Recovery Bootloader and Rollback
+#
+# end of Recovery Bootloader and Rollback
+
+# default:
+CONFIG_BOOTLOADER_OFFSET_IN_FLASH=0x1000
+# default:
+CONFIG_BOOTLOADER_COMPILER_OPTIMIZATION_SIZE=y
+# default:
+# CONFIG_BOOTLOADER_COMPILER_OPTIMIZATION_DEBUG is not set
+# default:
+# CONFIG_BOOTLOADER_COMPILER_OPTIMIZATION_PERF is not set
+
+#
+# Log
+#
+# default:
+CONFIG_BOOTLOADER_LOG_VERSION_1=y
+# default:
+CONFIG_BOOTLOADER_LOG_VERSION=1
+# default:
+# CONFIG_BOOTLOADER_LOG_LEVEL_NONE is not set
+# default:
+# CONFIG_BOOTLOADER_LOG_LEVEL_ERROR is not set
+# default:
+# CONFIG_BOOTLOADER_LOG_LEVEL_WARN is not set
+# default:
+CONFIG_BOOTLOADER_LOG_LEVEL_INFO=y
+# default:
+# CONFIG_BOOTLOADER_LOG_LEVEL_DEBUG is not set
+# default:
+# CONFIG_BOOTLOADER_LOG_LEVEL_VERBOSE is not set
+# default:
+CONFIG_BOOTLOADER_LOG_LEVEL=3
+
+#
+# Format
+#
+# default:
+# CONFIG_BOOTLOADER_LOG_COLORS is not set
+# default:
+CONFIG_BOOTLOADER_LOG_TIMESTAMP_SOURCE_CPU_TICKS=y
+# end of Format
+
+#
+# Settings
+#
+# default:
+CONFIG_BOOTLOADER_LOG_MODE_TEXT_EN=y
+# default:
+CONFIG_BOOTLOADER_LOG_MODE_TEXT=y
+# end of Settings
+# end of Log
+
+# default:
+CONFIG_BOOTLOADER_CPU_CLK_FREQ_MHZ=80
+
+#
+# Serial Flash Configurations
+#
+# default:
+# CONFIG_BOOTLOADER_FLASH_DC_AWARE is not set
+# default:
+CONFIG_BOOTLOADER_FLASH_XMC_SUPPORT=y
+# end of Serial Flash Configurations
+
+# default:
+# CONFIG_BOOTLOADER_VDDSDIO_BOOST_1_8V is not set
+# default:
+CONFIG_BOOTLOADER_VDDSDIO_BOOST_1_9V=y
+# default:
+# CONFIG_BOOTLOADER_FACTORY_RESET is not set
+# default:
+# CONFIG_BOOTLOADER_APP_TEST is not set
+# default:
+CONFIG_BOOTLOADER_REGION_PROTECTION_ENABLE=y
+# default:
+CONFIG_BOOTLOADER_WDT_ENABLE=y
+# default:
+# CONFIG_BOOTLOADER_WDT_DISABLE_IN_USER_CODE is not set
+# default:
+CONFIG_BOOTLOADER_WDT_TIME_MS=9000
+# default:
+# CONFIG_BOOTLOADER_SKIP_VALIDATE_IN_DEEP_SLEEP is not set
+# default:
+# CONFIG_BOOTLOADER_SKIP_VALIDATE_ON_POWER_ON is not set
+# default:
+# CONFIG_BOOTLOADER_SKIP_VALIDATE_ALWAYS is not set
+# default:
+CONFIG_BOOTLOADER_RESERVE_RTC_SIZE=0
+# default:
+# CONFIG_BOOTLOADER_CUSTOM_RESERVE_RTC is not set
+# end of Bootloader config
+
+#
+# Security features
+#
+# default:
+CONFIG_SECURE_BOOT_V1_SUPPORTED=y
+# default:
+# CONFIG_SECURE_SIGNED_APPS_NO_SECURE_BOOT is not set
+# default:
+# CONFIG_SECURE_BOOT is not set
+# default:
+# CONFIG_SECURE_FLASH_ENC_ENABLED is not set
+# end of Security features
+
+#
+# Application manager
+#
+# default:
+CONFIG_APP_COMPILE_TIME_DATE=y
+# default:
+# CONFIG_APP_EXCLUDE_PROJECT_VER_VAR is not set
+# default:
+# CONFIG_APP_EXCLUDE_PROJECT_NAME_VAR is not set
+# default:
+# CONFIG_APP_PROJECT_VER_FROM_CONFIG is not set
+# default:
+CONFIG_APP_RETRIEVE_LEN_ELF_SHA=9
+# end of Application manager
+
+# default:
+CONFIG_ESP_ROM_HAS_CRC_LE=y
+# default:
+CONFIG_ESP_ROM_HAS_CRC_BE=y
+# default:
+CONFIG_ESP_ROM_HAS_MZ_CRC32=y
+# default:
+CONFIG_ESP_ROM_HAS_JPEG_DECODE=y
+# default:
+CONFIG_ESP_ROM_HAS_UART_BUF_SWITCH=y
+# default:
+CONFIG_ESP_ROM_NEEDS_SWSETUP_WORKAROUND=y
+# default:
+CONFIG_ESP_ROM_HAS_NEWLIB=y
+# default:
+CONFIG_ESP_ROM_HAS_NEWLIB_NANO_FORMAT=y
+# default:
+CONFIG_ESP_ROM_HAS_NEWLIB_32BIT_TIME=y
+# default:
+CONFIG_ESP_ROM_HAS_SW_FLOAT=y
+# default:
+CONFIG_ESP_ROM_USB_OTG_NUM=-1
+# default:
+CONFIG_ESP_ROM_USB_SERIAL_DEVICE_NUM=-1
+# default:
+CONFIG_ESP_ROM_SUPPORT_DEEP_SLEEP_WAKEUP_STUB=y
+# default:
+CONFIG_ESP_ROM_HAS_OUTPUT_PUTC_FUNC=y
+
+#
+# Serial flasher config
+#
+# default:
+# CONFIG_ESPTOOLPY_NO_STUB is not set
+# default:
+# CONFIG_ESPTOOLPY_FLASHMODE_QIO is not set
+# default:
+# CONFIG_ESPTOOLPY_FLASHMODE_QOUT is not set
+# default:
+CONFIG_ESPTOOLPY_FLASHMODE_DIO=y
+# default:
+# CONFIG_ESPTOOLPY_FLASHMODE_DOUT is not set
+# default:
+CONFIG_ESPTOOLPY_FLASH_SAMPLE_MODE_STR=y
+# default:
+CONFIG_ESPTOOLPY_FLASHMODE="dio"
+# default:
+# CONFIG_ESPTOOLPY_FLASHFREQ_80M is not set
+# default:
+CONFIG_ESPTOOLPY_FLASHFREQ_40M=y
+# default:
+# CONFIG_ESPTOOLPY_FLASHFREQ_26M is not set
+# default:
+# CONFIG_ESPTOOLPY_FLASHFREQ_20M is not set
+# default:
+CONFIG_ESPTOOLPY_FLASHFREQ="40m"
+# default:
+# CONFIG_ESPTOOLPY_FLASHSIZE_1MB is not set
+# default:
+CONFIG_ESPTOOLPY_FLASHSIZE_2MB=y
+# default:
+# CONFIG_ESPTOOLPY_FLASHSIZE_4MB is not set
+# default:
+# CONFIG_ESPTOOLPY_FLASHSIZE_8MB is not set
+# default:
+# CONFIG_ESPTOOLPY_FLASHSIZE_16MB is not set
+# default:
+# CONFIG_ESPTOOLPY_FLASHSIZE_32MB is not set
+# default:
+# CONFIG_ESPTOOLPY_FLASHSIZE_64MB is not set
+# default:
+# CONFIG_ESPTOOLPY_FLASHSIZE_128MB is not set
+# default:
+CONFIG_ESPTOOLPY_FLASHSIZE="2MB"
+# default:
+# CONFIG_ESPTOOLPY_HEADER_FLASHSIZE_UPDATE is not set
+# default:
+CONFIG_ESPTOOLPY_BEFORE_RESET=y
+# default:
+# CONFIG_ESPTOOLPY_BEFORE_NORESET is not set
+# default:
+CONFIG_ESPTOOLPY_BEFORE="default-reset"
+# default:
+CONFIG_ESPTOOLPY_AFTER_RESET=y
+# default:
+# CONFIG_ESPTOOLPY_AFTER_NORESET is not set
+# default:
+CONFIG_ESPTOOLPY_AFTER="hard-reset"
+# default:
+CONFIG_ESPTOOLPY_MONITOR_BAUD=115200
+# end of Serial flasher config
+
+#
+# Partition Table
+#
+# default:
+CONFIG_PARTITION_TABLE_SINGLE_APP=y
+# default:
+# CONFIG_PARTITION_TABLE_SINGLE_APP_LARGE is not set
+# default:
+# CONFIG_PARTITION_TABLE_TWO_OTA is not set
+# default:
+# CONFIG_PARTITION_TABLE_TWO_OTA_LARGE is not set
+# default:
+# CONFIG_PARTITION_TABLE_CUSTOM is not set
+# default:
+CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="partitions.csv"
+# default:
+CONFIG_PARTITION_TABLE_FILENAME="partitions_singleapp.csv"
+# default:
+CONFIG_PARTITION_TABLE_OFFSET=0x8000
+# default:
+CONFIG_PARTITION_TABLE_MD5=y
+# end of Partition Table
+
+#
+# Compiler options
+#
+# default:
+CONFIG_COMPILER_OPTIMIZATION_DEBUG=y
+# default:
+# CONFIG_COMPILER_OPTIMIZATION_SIZE is not set
+# default:
+# CONFIG_COMPILER_OPTIMIZATION_PERF is not set
+# default:
+# CONFIG_COMPILER_OPTIMIZATION_NONE is not set
+# default:
+CONFIG_COMPILER_OPTIMIZATION_ASSERTIONS_ENABLE=y
+# default:
+# CONFIG_COMPILER_OPTIMIZATION_ASSERTIONS_SILENT is not set
+# default:
+# CONFIG_COMPILER_OPTIMIZATION_ASSERTIONS_DISABLE is not set
+# default:
+# CONFIG_COMPILER_ASSERT_NDEBUG_EVALUATE is not set
+# default:
+CONFIG_COMPILER_FLOAT_LIB_FROM_GCCLIB=y
+# default:
+CONFIG_COMPILER_OPTIMIZATION_ASSERTION_LEVEL=2
+# default:
+# CONFIG_COMPILER_OPTIMIZATION_CHECKS_SILENT is not set
+# default:
+CONFIG_COMPILER_HIDE_PATHS_MACROS=y
+# default:
+# CONFIG_COMPILER_CXX_EXCEPTIONS is not set
+# default:
+# CONFIG_COMPILER_CXX_RTTI is not set
+# default:
+CONFIG_COMPILER_STACK_CHECK_MODE_NONE=y
+# default:
+# CONFIG_COMPILER_STACK_CHECK_MODE_NORM is not set
+# default:
+# CONFIG_COMPILER_STACK_CHECK_MODE_STRONG is not set
+# default:
+# CONFIG_COMPILER_STACK_CHECK_MODE_ALL is not set
+# default:
+# CONFIG_COMPILER_NO_MERGE_CONSTANTS is not set
+# default:
+# CONFIG_COMPILER_WARN_WRITE_STRINGS is not set
+# default:
+# CONFIG_COMPILER_DISABLE_DEFAULT_ERRORS is not set
+# default:
+# CONFIG_COMPILER_DISABLE_GCC12_WARNINGS is not set
+# default:
+# CONFIG_COMPILER_DISABLE_GCC13_WARNINGS is not set
+# default:
+# CONFIG_COMPILER_DISABLE_GCC14_WARNINGS is not set
+# default:
+# CONFIG_COMPILER_DISABLE_GCC15_WARNINGS is not set
+# default:
+# CONFIG_COMPILER_DUMP_RTL_FILES is not set
+# default:
+CONFIG_COMPILER_RT_LIB_GCCLIB=y
+# default:
+CONFIG_COMPILER_RT_LIB_NAME="gcc"
+# default:
+CONFIG_COMPILER_ORPHAN_SECTIONS_ERROR=y
+# default:
+# CONFIG_COMPILER_ORPHAN_SECTIONS_WARNING is not set
+# default:
+# CONFIG_COMPILER_ORPHAN_SECTIONS_PLACE is not set
+# default:
+# CONFIG_COMPILER_STATIC_ANALYZER is not set
+# default:
+CONFIG_COMPILER_CXX_GLIBCXX_CONSTEXPR_NO_CHANGE=y
+# default:
+# CONFIG_COMPILER_CXX_GLIBCXX_CONSTEXPR_COLD_CONSTEXPR is not set
+# default:
+# CONFIG_COMPILER_CXX_GLIBCXX_CONSTEXPR_COLD is not set
+# end of Compiler options
+
+#
+# Component config
+#
+
+#
+# Bluetooth
+#
+# default:
+# CONFIG_BT_ENABLED is not set
+
+#
+# Common Options
+#
+
+#
+# BLE Log
+#
+# default:
+# CONFIG_BLE_LOG_ENABLED is not set
+# end of BLE Log
+
+# default:
+# CONFIG_BT_BLE_LOG_SPI_OUT_ENABLED is not set
+# default:
+# CONFIG_BT_BLE_LOG_UHCI_OUT_ENABLED is not set
+# default:
+# CONFIG_BT_LE_USED_MEM_STATISTICS_ENABLED is not set
+# end of Common Options
+# end of Bluetooth
+
+#
+# Console Library
+#
+# default:
+# CONFIG_CONSOLE_SORTED_HELP is not set
+# end of Console Library
+
+#
+# Legacy Driver Configurations
+#
+
+#
+# Legacy TWAI Driver Configurations
+#
+# default:
+# CONFIG_TWAI_ISR_IN_IRAM_LEGACY is not set
+# default:
+# CONFIG_TWAI_SUPPRESS_DEPRECATE_WARN is not set
+# default:
+# CONFIG_TWAI_SKIP_LEGACY_CONFLICT_CHECK is not set
+# end of Legacy TWAI Driver Configurations
+
+#
+# Legacy I2C Driver Configurations
+#
+# default:
+# CONFIG_I2C_SUPPRESS_DEPRECATE_WARN is not set
+# default:
+# CONFIG_I2C_SKIP_LEGACY_CONFLICT_CHECK is not set
+# end of Legacy I2C Driver Configurations
+
+#
+# Legacy Touch Sensor Driver Configurations
+#
+# default:
+# CONFIG_TOUCH_SUPPRESS_DEPRECATE_WARN is not set
+# default:
+# CONFIG_TOUCH_SKIP_LEGACY_CONFLICT_CHECK is not set
+# end of Legacy Touch Sensor Driver Configurations
+# end of Legacy Driver Configurations
+
+#
+# eFuse Bit Manager
+#
+# default:
+# CONFIG_EFUSE_CUSTOM_TABLE is not set
+# default:
+# CONFIG_EFUSE_VIRTUAL is not set
+# default:
+# CONFIG_EFUSE_CODE_SCHEME_COMPAT_NONE is not set
+# default:
+CONFIG_EFUSE_CODE_SCHEME_COMPAT_3_4=y
+# default:
+# CONFIG_EFUSE_CODE_SCHEME_COMPAT_REPEAT is not set
+# default:
+CONFIG_EFUSE_MAX_BLK_LEN=192
+# end of eFuse Bit Manager
+
+#
+# ESP-TLS
+#
+# default:
+CONFIG_ESP_TLS_USING_MBEDTLS=y
+# default:
+# CONFIG_ESP_TLS_CUSTOM_STACK is not set
+# default:
+# CONFIG_ESP_TLS_USE_SECURE_ELEMENT is not set
+# default:
+# CONFIG_ESP_TLS_CLIENT_SESSION_TICKETS is not set
+# default:
+# CONFIG_ESP_TLS_SERVER_SESSION_TICKETS is not set
+# default:
+# CONFIG_ESP_TLS_SERVER_CERT_SELECT_HOOK is not set
+# default:
+# CONFIG_ESP_TLS_SERVER_MIN_AUTH_MODE_OPTIONAL is not set
+# default:
+# CONFIG_ESP_TLS_PSK_VERIFICATION is not set
+# default:
+# CONFIG_ESP_TLS_INSECURE is not set
+# default:
+CONFIG_ESP_TLS_DYN_BUF_STRATEGY_SUPPORTED=y
+# end of ESP-TLS
+
+#
+# ADC and ADC Calibration
+#
+# default:
+# CONFIG_ADC_ONESHOT_CTRL_FUNC_IN_IRAM is not set
+# default:
+# CONFIG_ADC_CONTINUOUS_ISR_IRAM_SAFE is not set
+
+#
+# ADC Calibration Configurations
+#
+# default:
+CONFIG_ADC_CALI_EFUSE_TP_ENABLE=y
+# default:
+CONFIG_ADC_CALI_EFUSE_VREF_ENABLE=y
+# default:
+CONFIG_ADC_CALI_LUT_ENABLE=y
+# end of ADC Calibration Configurations
+
+# default:
+CONFIG_ADC_DISABLE_DAC_OUTPUT=y
+# default:
+# CONFIG_ADC_ENABLE_DEBUG_LOG is not set
+# end of ADC and ADC Calibration
+
+#
+# Wireless Coexistence
+#
+# default:
+CONFIG_ESP_COEX_ENABLED=y
+# default:
+# CONFIG_ESP_COEX_GPIO_DEBUG is not set
+# end of Wireless Coexistence
+
+#
+# Common ESP-related
+#
+# default:
+CONFIG_ESP_ERR_TO_NAME_LOOKUP=y
+# end of Common ESP-related
+
+#
+# ESP-Driver:DAC Configurations
+#
+# default:
+# CONFIG_DAC_CTRL_FUNC_IN_IRAM is not set
+# default:
+# CONFIG_DAC_ISR_IRAM_SAFE is not set
+# default:
+# CONFIG_DAC_ENABLE_DEBUG_LOG is not set
+# default:
+CONFIG_DAC_DMA_AUTO_16BIT_ALIGN=y
+# end of ESP-Driver:DAC Configurations
+
+#
+# ESP-Driver:GPIO Configurations
+#
+# default:
+# CONFIG_GPIO_CTRL_FUNC_IN_IRAM is not set
+# end of ESP-Driver:GPIO Configurations
+
+#
+# ESP-Driver:GPTimer Configurations
+#
+# default:
+CONFIG_GPTIMER_ISR_HANDLER_IN_IRAM=y
+# default:
+# CONFIG_GPTIMER_CTRL_FUNC_IN_IRAM is not set
+# default:
+# CONFIG_GPTIMER_ISR_CACHE_SAFE is not set
+# default:
+CONFIG_GPTIMER_OBJ_CACHE_SAFE=y
+# default:
+# CONFIG_GPTIMER_ENABLE_DEBUG_LOG is not set
+# end of ESP-Driver:GPTimer Configurations
+
+#
+# ESP-Driver:I2C Configurations
+#
+# default:
+# CONFIG_I2C_ISR_IRAM_SAFE is not set
+# default:
+# CONFIG_I2C_ENABLE_DEBUG_LOG is not set
+# default:
+CONFIG_I2C_MASTER_ISR_HANDLER_IN_IRAM=y
+# end of ESP-Driver:I2C Configurations
+
+#
+# ESP-Driver:I2S Configurations
+#
+# default:
+# CONFIG_I2S_ISR_IRAM_SAFE is not set
+# default:
+# CONFIG_I2S_CTRL_FUNC_IN_IRAM is not set
+# default:
+# CONFIG_I2S_ENABLE_DEBUG_LOG is not set
+# end of ESP-Driver:I2S Configurations
+
+#
+# ESP-Driver:I3C Master Configurations
+#
+# default:
+# CONFIG_I3C_MASTER_ISR_CACHE_SAFE is not set
+# default:
+# CONFIG_I3C_MASTER_ENABLE_DEBUG_LOG is not set
+# default:
+# CONFIG_I3C_MASTER_ISR_HANDLER_IN_IRAM is not set
+# end of ESP-Driver:I3C Master Configurations
+
+#
+# ESP-Driver:LEDC Configurations
+#
+# default:
+# CONFIG_LEDC_CTRL_FUNC_IN_IRAM is not set
+# end of ESP-Driver:LEDC Configurations
+
+#
+# ESP-Driver:MCPWM Configurations
+#
+# default:
+CONFIG_MCPWM_ISR_HANDLER_IN_IRAM=y
+# default:
+# CONFIG_MCPWM_ISR_CACHE_SAFE is not set
+# default:
+# CONFIG_MCPWM_CTRL_FUNC_IN_IRAM is not set
+# default:
+CONFIG_MCPWM_OBJ_CACHE_SAFE=y
+# default:
+# CONFIG_MCPWM_ENABLE_DEBUG_LOG is not set
+# end of ESP-Driver:MCPWM Configurations
+
+#
+# ESP-Driver:PCNT Configurations
+#
+# default:
+# CONFIG_PCNT_CTRL_FUNC_IN_IRAM is not set
+# default:
+# CONFIG_PCNT_ISR_IRAM_SAFE is not set
+# default:
+# CONFIG_PCNT_ENABLE_DEBUG_LOG is not set
+# end of ESP-Driver:PCNT Configurations
+
+#
+# ESP-Driver:RMT Configurations
+#
+# default:
+CONFIG_RMT_ENCODER_FUNC_IN_IRAM=y
+# default:
+CONFIG_RMT_TX_ISR_HANDLER_IN_IRAM=y
+# default:
+CONFIG_RMT_RX_ISR_HANDLER_IN_IRAM=y
+# default:
+# CONFIG_RMT_RECV_FUNC_IN_IRAM is not set
+# default:
+# CONFIG_RMT_TX_ISR_CACHE_SAFE is not set
+# default:
+# CONFIG_RMT_RX_ISR_CACHE_SAFE is not set
+# default:
+CONFIG_RMT_OBJ_CACHE_SAFE=y
+# default:
+# CONFIG_RMT_ENABLE_DEBUG_LOG is not set
+# default:
+# CONFIG_RMT_ISR_IRAM_SAFE is not set
+# end of ESP-Driver:RMT Configurations
+
+#
+# ESP-Driver:Sigma Delta Modulator Configurations
+#
+# default:
+# CONFIG_SDM_CTRL_FUNC_IN_IRAM is not set
+# default:
+# CONFIG_SDM_ENABLE_DEBUG_LOG is not set
+# end of ESP-Driver:Sigma Delta Modulator Configurations
+
+#
+# ESP-Driver:SD Host SDMMC Controller Configurations
+#
+# default:
+# CONFIG_SD_HOST_SDMMC_ISR_CACHE_SAFE is not set
+# end of ESP-Driver:SD Host SDMMC Controller Configurations
+
+#
+# ESP-Driver:SPI Configurations
+#
+# default:
+CONFIG_SPI_MASTER_ISR_IN_IRAM=y
+# default:
+# CONFIG_SPI_SLAVE_IN_IRAM is not set
+# default:
+CONFIG_SPI_SLAVE_ISR_IN_IRAM=y
+# end of ESP-Driver:SPI Configurations
+
+#
+# ESP-Driver:Touch Sensor Configurations
+#
+# default:
+# CONFIG_TOUCH_CTRL_FUNC_IN_IRAM is not set
+# default:
+# CONFIG_TOUCH_ISR_IRAM_SAFE is not set
+# default:
+# CONFIG_TOUCH_ENABLE_DEBUG_LOG is not set
+# default:
+# CONFIG_TOUCH_SKIP_FSM_CHECK is not set
+# end of ESP-Driver:Touch Sensor Configurations
+
+#
+# ESP-Driver:TWAI Configurations
+#
+# default:
+# CONFIG_TWAI_ISR_IN_IRAM is not set
+# default:
+# CONFIG_TWAI_IO_FUNC_IN_IRAM is not set
+# default:
+# CONFIG_TWAI_ISR_CACHE_SAFE is not set
+# default:
+# CONFIG_TWAI_ENABLE_DEBUG_LOG is not set
+# end of ESP-Driver:TWAI Configurations
+
+#
+# ESP-Driver:UART Configurations
+#
+# default:
+# CONFIG_UART_ISR_IN_IRAM is not set
+# end of ESP-Driver:UART Configurations
+
+#
+# ESP-Driver:UHCI Configurations
+#
+# default:
+# CONFIG_UHCI_ISR_HANDLER_IN_IRAM is not set
+# default:
+# CONFIG_UHCI_ISR_CACHE_SAFE is not set
+# default:
+# CONFIG_UHCI_ENABLE_DEBUG_LOG is not set
+# end of ESP-Driver:UHCI Configurations
+
+#
+# Ethernet
+#
+# default:
+CONFIG_ETH_ENABLED=y
+# default:
+CONFIG_ETH_USE_ESP32_EMAC=y
+# default:
+CONFIG_ETH_DMA_BUFFER_SIZE=512
+# default:
+CONFIG_ETH_DMA_RX_BUFFER_NUM=10
+# default:
+CONFIG_ETH_DMA_TX_BUFFER_NUM=10
+# default:
+# CONFIG_ETH_IRAM_OPTIMIZATION is not set
+# default:
+CONFIG_ETH_USE_SPI_ETHERNET=y
+# default:
+# CONFIG_ETH_USE_OPENETH is not set
+# default:
+# CONFIG_ETH_TRANSMIT_MUTEX is not set
+# end of Ethernet
+
+#
+# Event Loop Library
+#
+# default:
+# CONFIG_ESP_EVENT_LOOP_PROFILING is not set
+# default:
+CONFIG_ESP_EVENT_POST_FROM_ISR=y
+# default:
+CONFIG_ESP_EVENT_POST_FROM_IRAM_ISR=y
+# end of Event Loop Library
+
+#
+# GDB Stub
+#
+# default:
+CONFIG_ESP_GDBSTUB_ENABLED=y
+# default:
+# CONFIG_ESP_SYSTEM_GDBSTUB_RUNTIME is not set
+# default:
+CONFIG_ESP_GDBSTUB_SUPPORT_TASKS=y
+# default:
+CONFIG_ESP_GDBSTUB_MAX_TASKS=32
+# end of GDB Stub
+
+#
+# ESP HID
+#
+# default:
+CONFIG_ESPHID_TASK_SIZE_BT=2048
+# default:
+CONFIG_ESPHID_TASK_SIZE_BLE=4096
+# end of ESP HID
+
+#
+# ESP HTTP client
+#
+# default:
+CONFIG_ESP_HTTP_CLIENT_ENABLE_HTTPS=y
+# default:
+# CONFIG_ESP_HTTP_CLIENT_ENABLE_BASIC_AUTH is not set
+# default:
+# CONFIG_ESP_HTTP_CLIENT_ENABLE_DIGEST_AUTH is not set
+# default:
+# CONFIG_ESP_HTTP_CLIENT_ENABLE_CUSTOM_TRANSPORT is not set
+# default:
+# CONFIG_ESP_HTTP_CLIENT_ENABLE_GET_CONTENT_RANGE is not set
+# default:
+CONFIG_ESP_HTTP_CLIENT_EVENT_POST_TIMEOUT=2000
+# default:
+# CONFIG_ESP_HTTP_CLIENT_SAVE_RESPONSE_HEADERS is not set
+# end of ESP HTTP client
+
+#
+# HTTP Server
+#
+# default:
+CONFIG_HTTPD_MAX_REQ_HDR_LEN=1024
+# default:
+CONFIG_HTTPD_MAX_URI_LEN=512
+# default:
+CONFIG_HTTPD_ERR_RESP_NO_DELAY=y
+# default:
+CONFIG_HTTPD_PURGE_BUF_LEN=32
+# default:
+# CONFIG_HTTPD_LOG_PURGE_DATA is not set
+# default:
+# CONFIG_HTTPD_WS_SUPPORT is not set
+# default:
+# CONFIG_HTTPD_QUEUE_WORK_BLOCKING is not set
+# default:
+CONFIG_HTTPD_SERVER_EVENT_POST_TIMEOUT=2000
+# end of HTTP Server
+
+#
+# ESP HTTPS OTA
+#
+# default:
+# CONFIG_ESP_HTTPS_OTA_DECRYPT_CB is not set
+# default:
+# CONFIG_ESP_HTTPS_OTA_ALLOW_HTTP is not set
+# default:
+CONFIG_ESP_HTTPS_OTA_EVENT_POST_TIMEOUT=2000
+# default:
+# CONFIG_ESP_HTTPS_OTA_ENABLE_PARTIAL_DOWNLOAD is not set
+# end of ESP HTTPS OTA
+
+#
+# ESP HTTPS server
+#
+# default:
+# CONFIG_ESP_HTTPS_SERVER_ENABLE is not set
+# default:
+CONFIG_ESP_HTTPS_SERVER_EVENT_POST_TIMEOUT=2000
+# default:
+# CONFIG_ESP_HTTPS_SERVER_CERT_SELECT_HOOK is not set
+# end of ESP HTTPS server
+
+#
+# Hardware Settings
+#
+# default:
+CONFIG_ESP_HW_SUPPORT_FUNC_IN_IRAM=y
+
+#
+# Chip revision
+#
+# default:
+CONFIG_ESP32_REV_MIN_0=y
+# default:
+# CONFIG_ESP32_REV_MIN_1 is not set
+# default:
+# CONFIG_ESP32_REV_MIN_1_1 is not set
+# default:
+# CONFIG_ESP32_REV_MIN_2 is not set
+# default:
+# CONFIG_ESP32_REV_MIN_3 is not set
+# default:
+# CONFIG_ESP32_REV_MIN_3_1 is not set
+# default:
+CONFIG_ESP32_REV_MIN=0
+# default:
+CONFIG_ESP32_REV_MIN_FULL=0
+# default:
+CONFIG_ESP_REV_MIN_FULL=0
+
+#
+# Maximum Supported ESP32 Revision (Rev v3.99)
+#
+# default:
+CONFIG_ESP32_REV_MAX_FULL=399
+# default:
+CONFIG_ESP_REV_MAX_FULL=399
+# default:
+CONFIG_ESP_EFUSE_BLOCK_REV_MIN_FULL=0
+# default:
+CONFIG_ESP_EFUSE_BLOCK_REV_MAX_FULL=99
+
+#
+# Maximum Supported ESP32 eFuse Block Revision (eFuse Block Rev v0.99)
+#
+# end of Chip revision
+
+#
+# MAC Config
+#
+# default:
+CONFIG_ESP_MAC_ADDR_UNIVERSE_WIFI_STA=y
+# default:
+CONFIG_ESP_MAC_ADDR_UNIVERSE_WIFI_AP=y
+# default:
+CONFIG_ESP_MAC_ADDR_UNIVERSE_BT=y
+# default:
+CONFIG_ESP_MAC_ADDR_UNIVERSE_ETH=y
+# default:
+CONFIG_ESP_MAC_UNIVERSAL_MAC_ADDRESSES_FOUR=y
+# default:
+CONFIG_ESP_MAC_UNIVERSAL_MAC_ADDRESSES=4
+# default:
+# CONFIG_ESP32_UNIVERSAL_MAC_ADDRESSES_TWO is not set
+# default:
+CONFIG_ESP32_UNIVERSAL_MAC_ADDRESSES_FOUR=y
+# default:
+CONFIG_ESP32_UNIVERSAL_MAC_ADDRESSES=4
+# default:
+# CONFIG_ESP_MAC_IGNORE_MAC_CRC_ERROR is not set
+# default:
+# CONFIG_ESP_MAC_USE_CUSTOM_MAC_AS_BASE_MAC is not set
+# end of MAC Config
+
+#
+# Sleep Config
+#
+# default:
+# CONFIG_ESP_SLEEP_POWER_DOWN_FLASH is not set
+# default:
+CONFIG_ESP_SLEEP_FLASH_LEAKAGE_WORKAROUND=y
+# default:
+# CONFIG_ESP_SLEEP_MSPI_NEED_ALL_IO_PU is not set
+# default:
+CONFIG_ESP_SLEEP_RTC_BUS_ISO_WORKAROUND=y
+# default:
+# CONFIG_ESP_SLEEP_GPIO_RESET_WORKAROUND is not set
+# default:
+CONFIG_ESP_SLEEP_WAIT_FLASH_READY_EXTRA_DELAY=2000
+# default:
+# CONFIG_ESP_SLEEP_CACHE_SAFE_ASSERTION is not set
+# default:
+# CONFIG_ESP_SLEEP_DEBUG is not set
+# default:
+CONFIG_ESP_SLEEP_GPIO_ENABLE_INTERNAL_RESISTORS=y
+# end of Sleep Config
+
+#
+# RTC Clock Config
+#
+# default:
+CONFIG_RTC_CLK_SRC_INT_RC=y
+# default:
+# CONFIG_RTC_CLK_SRC_EXT_CRYS is not set
+# default:
+# CONFIG_RTC_CLK_SRC_EXT_OSC is not set
+# default:
+# CONFIG_RTC_CLK_SRC_INT_8MD256 is not set
+# default:
+CONFIG_RTC_CLK_CAL_CYCLES=1024
+# default:
+CONFIG_RTC_CLK_FUNC_IN_IRAM=y
+# default:
+CONFIG_RTC_TIME_FUNC_IN_IRAM=y
+# end of RTC Clock Config
+
+#
+# Peripheral Control
+#
+# default:
+CONFIG_ESP_PERIPH_CTRL_FUNC_IN_IRAM=y
+# default:
+CONFIG_ESP_REGI2C_CTRL_FUNC_IN_IRAM=y
+# end of Peripheral Control
+
+#
+# Main XTAL Config
+#
+# default:
+# CONFIG_XTAL_FREQ_26 is not set
+# default:
+# CONFIG_XTAL_FREQ_32 is not set
+# default:
+CONFIG_XTAL_FREQ_40=y
+# default:
+# CONFIG_XTAL_FREQ_AUTO is not set
+# default:
+CONFIG_XTAL_FREQ=40
+# end of Main XTAL Config
+
+#
+# Power Supplier
+#
+
+#
+# Brownout Detector
+#
+# default:
+CONFIG_ESP_BROWNOUT_DET=y
+# default:
+CONFIG_ESP_BROWNOUT_DET_LVL_SEL_0=y
+# default:
+# CONFIG_ESP_BROWNOUT_DET_LVL_SEL_1 is not set
+# default:
+# CONFIG_ESP_BROWNOUT_DET_LVL_SEL_2 is not set
+# default:
+# CONFIG_ESP_BROWNOUT_DET_LVL_SEL_3 is not set
+# default:
+# CONFIG_ESP_BROWNOUT_DET_LVL_SEL_4 is not set
+# default:
+# CONFIG_ESP_BROWNOUT_DET_LVL_SEL_5 is not set
+# default:
+# CONFIG_ESP_BROWNOUT_DET_LVL_SEL_6 is not set
+# default:
+# CONFIG_ESP_BROWNOUT_DET_LVL_SEL_7 is not set
+# default:
+CONFIG_ESP_BROWNOUT_DET_LVL=0
+# default:
+CONFIG_ESP_BROWNOUT_USE_INTR=y
+# end of Brownout Detector
+# end of Power Supplier
+
+# default:
+CONFIG_ESP_SPI_BUS_LOCK_ISR_FUNCS_IN_IRAM=y
+# default:
+CONFIG_ESP_INTR_IN_IRAM=y
+# end of Hardware Settings
+
+#
+# ESP-Driver:LCD Controller Configurations
+#
+# default:
+# CONFIG_LCD_ENABLE_DEBUG_LOG is not set
+# end of ESP-Driver:LCD Controller Configurations
+
+#
+# LibC
+#
+# default:
+# CONFIG_LIBC_NEWLIB is not set
+# default:
+CONFIG_LIBC_PICOLIBC=y
+# default:
+CONFIG_LIBC_PICOLIBC_NEWLIB_COMPATIBILITY=y
+# default:
+CONFIG_LIBC_MISC_IN_IRAM=y
+# default:
+CONFIG_LIBC_LOCKS_PLACE_IN_IRAM=y
+# default:
+CONFIG_LIBC_STDOUT_LINE_ENDING_CRLF=y
+# default:
+# CONFIG_LIBC_STDOUT_LINE_ENDING_LF is not set
+# default:
+# CONFIG_LIBC_STDOUT_LINE_ENDING_CR is not set
+# default:
+# CONFIG_LIBC_STDIN_LINE_ENDING_CRLF is not set
+# default:
+# CONFIG_LIBC_STDIN_LINE_ENDING_LF is not set
+# default:
+CONFIG_LIBC_STDIN_LINE_ENDING_CR=y
+# default:
+CONFIG_LIBC_TIME_SYSCALL_USE_RTC_HRT=y
+# default:
+# CONFIG_LIBC_TIME_SYSCALL_USE_RTC is not set
+# default:
+# CONFIG_LIBC_TIME_SYSCALL_USE_HRT is not set
+# default:
+# CONFIG_LIBC_TIME_SYSCALL_USE_NONE is not set
+# default:
+CONFIG_LIBC_ASSERT_BUFFER_SIZE=200
+# end of LibC
+
+#
+# ESP-MM: Memory Management Configurations
+#
+# end of ESP-MM: Memory Management Configurations
+
+#
+# ESP NETIF Adapter
+#
+# default:
+CONFIG_ESP_NETIF_LOST_IP_TIMER_ENABLE=y
+# default:
+CONFIG_ESP_NETIF_IP_LOST_TIMER_INTERVAL=120
+# default:
+# CONFIG_ESP_NETIF_PROVIDE_CUSTOM_IMPLEMENTATION is not set
+# default:
+CONFIG_ESP_NETIF_TCPIP_LWIP=y
+# default:
+# CONFIG_ESP_NETIF_LOOPBACK is not set
+# default:
+CONFIG_ESP_NETIF_USES_TCPIP_WITH_BSD_API=y
+# default:
+CONFIG_ESP_NETIF_REPORT_DATA_TRAFFIC=y
+# default:
+CONFIG_ESP_NETIF_RECEIVE_REPORT_ERRORS=y
+# default:
+# CONFIG_ESP_NETIF_L2_TAP is not set
+# default:
+# CONFIG_ESP_NETIF_BRIDGE_EN is not set
+# default:
+# CONFIG_ESP_NETIF_SET_DNS_PER_DEFAULT_NETIF is not set
+# end of ESP NETIF Adapter
+
+#
+# Partition API Configuration
+#
+# end of Partition API Configuration
+
+#
+# PHY
+#
+# default:
+CONFIG_ESP_PHY_ENABLED=y
+# default:
+CONFIG_ESP_PHY_CALIBRATION_AND_DATA_STORAGE=y
+# default:
+# CONFIG_ESP_PHY_INIT_DATA_IN_PARTITION is not set
+# default:
+CONFIG_ESP_PHY_MAX_WIFI_TX_POWER=20
+# default:
+CONFIG_ESP_PHY_MAX_TX_POWER=20
+# default:
+# CONFIG_ESP_PHY_REDUCE_TX_POWER is not set
+# default:
+# CONFIG_ESP_PHY_ENABLE_CERT_TEST is not set
+# default:
+CONFIG_ESP_PHY_RF_CAL_PARTIAL=y
+# default:
+# CONFIG_ESP_PHY_RF_CAL_NONE is not set
+# default:
+# CONFIG_ESP_PHY_RF_CAL_FULL is not set
+# default:
+CONFIG_ESP_PHY_CALIBRATION_MODE=0
+# default:
+CONFIG_ESP_PHY_PLL_TRACK_PERIOD_MS=1000
+# default:
+# CONFIG_ESP_PHY_PLL_TRACK_DEBUG is not set
+# default:
+# CONFIG_ESP_PHY_RECORD_USED_TIME is not set
+# default:
+CONFIG_ESP_PHY_IRAM_OPT=y
+# default:
+# CONFIG_ESP_PHY_DEBUG is not set
+# end of PHY
+
+#
+# Power Management
+#
+# default:
+# CONFIG_PM_SLEEP_FUNC_IN_IRAM is not set
+# default:
+# CONFIG_PM_ENABLE is not set
+# default:
+# CONFIG_PM_SLP_IRAM_OPT is not set
+# end of Power Management
+
+#
+# ESP PSRAM
+#
+# default:
+# CONFIG_SPIRAM is not set
+# end of ESP PSRAM
+
+#
+# ESP Ringbuf
+#
+# default:
+# CONFIG_RINGBUF_IN_IRAM is not set
+# default:
+# CONFIG_RINGBUF_PLACE_ISR_FUNCTIONS_INTO_FLASH is not set
+# end of ESP Ringbuf
+
+#
+# ESP-ROM
+#
+# default:
+CONFIG_ESP_ROM_PRINT_IN_IRAM=y
+# end of ESP-ROM
+
+#
+# ESP Security Specific
+#
+# end of ESP Security Specific
+
+#
+# ESP-STDIO
+#
+# default:
+CONFIG_ESP_CONSOLE_UART_DEFAULT=y
+# default:
+# CONFIG_ESP_CONSOLE_UART_CUSTOM is not set
+# default:
+# CONFIG_ESP_CONSOLE_NONE is not set
+# default:
+CONFIG_ESP_CONSOLE_UART=y
+# default:
+CONFIG_ESP_CONSOLE_UART_NUM=0
+# default:
+CONFIG_ESP_CONSOLE_ROM_SERIAL_PORT_NUM=0
+# default:
+CONFIG_ESP_CONSOLE_UART_BAUDRATE=115200
+# end of ESP-STDIO
+
+#
+# ESP System Settings
+#
+# default:
+# CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ_80 is not set
+# default:
+CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ_160=y
+# default:
+# CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ_240 is not set
+# default:
+CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ=160
+
+#
+# Memory
+#
+# default:
+# CONFIG_ESP32_USE_FIXED_STATIC_RAM_SIZE is not set
+
+#
+# Non-backward compatible options
+#
+# default:
+# CONFIG_ESP_SYSTEM_ESP32_SRAM1_REGION_AS_IRAM is not set
+# end of Non-backward compatible options
+# end of Memory
+
+#
+# Trace memory
+#
+# default:
+# CONFIG_ESP32_TRAX is not set
+# default:
+CONFIG_ESP32_TRACEMEM_RESERVE_DRAM=0x0
+# end of Trace memory
+
+# default:
+CONFIG_ESP_SYSTEM_IN_IRAM=y
+# default:
+# CONFIG_ESP_SYSTEM_PANIC_PRINT_HALT is not set
+# default:
+CONFIG_ESP_SYSTEM_PANIC_PRINT_REBOOT=y
+# default:
+# CONFIG_ESP_SYSTEM_PANIC_SILENT_REBOOT is not set
+# default:
+# CONFIG_ESP_SYSTEM_PANIC_GDBSTUB is not set
+# default:
+CONFIG_ESP_SYSTEM_PANIC_REBOOT_DELAY_SECONDS=0
+# default:
+CONFIG_ESP_SYSTEM_EVENT_QUEUE_SIZE=32
+# default:
+CONFIG_ESP_SYSTEM_EVENT_TASK_STACK_SIZE=2304
+# default:
+CONFIG_ESP_MAIN_TASK_STACK_SIZE=3584
+# default:
+CONFIG_ESP_MAIN_TASK_AFFINITY_CPU0=y
+# default:
+# CONFIG_ESP_MAIN_TASK_AFFINITY_CPU1 is not set
+# default:
+# CONFIG_ESP_MAIN_TASK_AFFINITY_NO_AFFINITY is not set
+# default:
+CONFIG_ESP_MAIN_TASK_AFFINITY=0x0
+# default:
+CONFIG_ESP_MINIMAL_SHARED_STACK_SIZE=2048
+# default:
+CONFIG_ESP_INT_WDT=y
+# default:
+CONFIG_ESP_INT_WDT_TIMEOUT_MS=300
+# default:
+CONFIG_ESP_INT_WDT_CHECK_CPU1=y
+# default:
+CONFIG_ESP_TASK_WDT_EN=y
+# default:
+CONFIG_ESP_TASK_WDT_INIT=y
+# default:
+# CONFIG_ESP_TASK_WDT_PANIC is not set
+# default:
+CONFIG_ESP_TASK_WDT_TIMEOUT_S=5
+# default:
+CONFIG_ESP_TASK_WDT_CHECK_IDLE_TASK_CPU0=y
+# default:
+CONFIG_ESP_TASK_WDT_CHECK_IDLE_TASK_CPU1=y
+# default:
+# CONFIG_ESP_PANIC_HANDLER_IRAM is not set
+# default:
+# CONFIG_ESP_DEBUG_STUBS_ENABLE is not set
+# default:
+CONFIG_ESP_DEBUG_OCDAWARE=y
+# default:
+# CONFIG_ESP_SYSTEM_CHECK_INT_LEVEL_5 is not set
+# default:
+CONFIG_ESP_SYSTEM_CHECK_INT_LEVEL_4=y
+# default:
+# CONFIG_ESP32_DISABLE_BASIC_ROM_CONSOLE is not set
+# end of ESP System Settings
+
+#
+# IPC (Inter-Processor Call)
+#
+# default:
+CONFIG_ESP_IPC_ENABLE=y
+# default:
+CONFIG_ESP_IPC_TASK_STACK_SIZE=1024
+# default:
+CONFIG_ESP_IPC_USES_CALLERS_PRIORITY=y
+# default:
+CONFIG_ESP_IPC_ISR_ENABLE=y
+# end of IPC (Inter-Processor Call)
+
+#
+# ESP Timer (High Resolution Timer)
+#
+# default:
+CONFIG_ESP_TIMER_IN_IRAM=y
+# default:
+# CONFIG_ESP_TIMER_PROFILING is not set
+# default:
+CONFIG_ESP_TIME_FUNCS_USE_RTC_TIMER=y
+# default:
+CONFIG_ESP_TIME_FUNCS_USE_ESP_TIMER=y
+# default:
+CONFIG_ESP_TIMER_TASK_STACK_SIZE=3584
+# default:
+CONFIG_ESP_TIMER_INTERRUPT_LEVEL=1
+# default:
+# CONFIG_ESP_TIMER_SHOW_EXPERIMENTAL is not set
+# default:
+CONFIG_ESP_TIMER_TASK_AFFINITY=0x0
+# default:
+CONFIG_ESP_TIMER_TASK_AFFINITY_CPU0=y
+# default:
+CONFIG_ESP_TIMER_ISR_AFFINITY_CPU0=y
+# default:
+# CONFIG_ESP_TIMER_SUPPORTS_ISR_DISPATCH_METHOD is not set
+# default:
+CONFIG_ESP_TIMER_IMPL_TG0_LAC=y
+# end of ESP Timer (High Resolution Timer)
+
+#
+# ESP Trace Configuration
+#
+# default:
+# CONFIG_ESP_TRACE_LIB_EXTERNAL is not set
+# default:
+CONFIG_ESP_TRACE_LIB_NONE=y
+# default:
+CONFIG_ESP_TRACE_LIB_NAME="none"
+# default:
+# CONFIG_ESP_TRACE_TRANSPORT_APPTRACE is not set
+# default:
+CONFIG_ESP_TRACE_TRANSPORT_NONE=y
+# default:
+CONFIG_ESP_TRACE_TRANSPORT_NAME="none"
+# end of ESP Trace Configuration
+
+#
+# Wi-Fi
+#
+# default:
+CONFIG_ESP_WIFI_ENABLED=y
+# default:
+CONFIG_ESP_WIFI_STATIC_RX_BUFFER_NUM=10
+# default:
+CONFIG_ESP_WIFI_DYNAMIC_RX_BUFFER_NUM=32
+# default:
+# CONFIG_ESP_WIFI_STATIC_TX_BUFFER is not set
+# default:
+CONFIG_ESP_WIFI_DYNAMIC_TX_BUFFER=y
+# default:
+CONFIG_ESP_WIFI_TX_BUFFER_TYPE=1
+# default:
+CONFIG_ESP_WIFI_DYNAMIC_TX_BUFFER_NUM=32
+# default:
+CONFIG_ESP_WIFI_STATIC_RX_MGMT_BUFFER=y
+# default:
+# CONFIG_ESP_WIFI_DYNAMIC_RX_MGMT_BUFFER is not set
+# default:
+CONFIG_ESP_WIFI_DYNAMIC_RX_MGMT_BUF=0
+# default:
+CONFIG_ESP_WIFI_RX_MGMT_BUF_NUM_DEF=5
+# default:
+# CONFIG_ESP_WIFI_CSI_ENABLED is not set
+# default:
+CONFIG_ESP_WIFI_AMPDU_TX_ENABLED=y
+# default:
+CONFIG_ESP_WIFI_TX_BA_WIN=6
+# default:
+CONFIG_ESP_WIFI_AMPDU_RX_ENABLED=y
+# default:
+CONFIG_ESP_WIFI_RX_BA_WIN=6
+# default:
+CONFIG_ESP_WIFI_NVS_ENABLED=y
+# default:
+CONFIG_ESP_WIFI_TASK_PINNED_TO_CORE_0=y
+# default:
+# CONFIG_ESP_WIFI_TASK_PINNED_TO_CORE_1 is not set
+# default:
+CONFIG_ESP_WIFI_SOFTAP_BEACON_MAX_LEN=752
+# default:
+CONFIG_ESP_WIFI_MGMT_SBUF_NUM=32
+# default:
+CONFIG_ESP_WIFI_IRAM_OPT=y
+# default:
+# CONFIG_ESP_WIFI_EXTRA_IRAM_OPT is not set
+# default:
+CONFIG_ESP_WIFI_RX_IRAM_OPT=y
+# default:
+CONFIG_ESP_WIFI_ENABLE_WPA3_SAE=y
+# default:
+CONFIG_ESP_WIFI_ENABLE_SAE_H2E=y
+# default:
+CONFIG_ESP_WIFI_ENABLE_SAE_PK=y
+# default:
+CONFIG_ESP_WIFI_SOFTAP_SAE_SUPPORT=y
+# default:
+CONFIG_ESP_WIFI_ENABLE_WPA3_OWE_STA=y
+# default:
+CONFIG_ESP_WIFI_WPA3_COMPATIBLE_SUPPORT=y
+# default:
+# CONFIG_ESP_WIFI_SLP_IRAM_OPT is not set
+# default:
+CONFIG_ESP_WIFI_SLP_DEFAULT_MIN_ACTIVE_TIME=50
+# default:
+# CONFIG_ESP_WIFI_BSS_MAX_IDLE_SUPPORT is not set
+# default:
+CONFIG_ESP_WIFI_SLP_DEFAULT_MAX_ACTIVE_TIME=10
+# default:
+CONFIG_ESP_WIFI_SLP_DEFAULT_WAIT_BROADCAST_DATA_TIME=15
+# default:
+CONFIG_ESP_WIFI_STA_DISCONNECTED_PM_ENABLE=y
+# default:
+CONFIG_ESP_WIFI_GMAC_SUPPORT=y
+# default:
+CONFIG_ESP_WIFI_SOFTAP_SUPPORT=y
+# default:
+# CONFIG_ESP_WIFI_SLP_BEACON_LOST_OPT is not set
+# default:
+CONFIG_ESP_WIFI_ESPNOW_MAX_ENCRYPT_NUM=7
+# default:
+# CONFIG_ESP_WIFI_NAN_SYNC_ENABLE is not set
+# default:
+CONFIG_ESP_WIFI_MBEDTLS_CRYPTO=y
+# default:
+CONFIG_ESP_WIFI_MBEDTLS_TLS_CLIENT=y
+# default:
+# CONFIG_ESP_WIFI_WAPI_PSK is not set
+# default:
+# CONFIG_ESP_WIFI_11KV_SUPPORT is not set
+# default:
+# CONFIG_ESP_WIFI_MBO_SUPPORT is not set
+# default:
+# CONFIG_ESP_WIFI_DPP_SUPPORT is not set
+# default:
+# CONFIG_ESP_WIFI_11R_SUPPORT is not set
+# default:
+# CONFIG_ESP_WIFI_WPS_SOFTAP_REGISTRAR is not set
+
+#
+# WPS Configuration Options
+#
+# default:
+# CONFIG_ESP_WIFI_WPS_STRICT is not set
+# default:
+# CONFIG_ESP_WIFI_WPS_PASSPHRASE is not set
+# default:
+# CONFIG_ESP_WIFI_WPS_RECONNECT_ON_FAIL is not set
+# end of WPS Configuration Options
+
+# default:
+# CONFIG_ESP_WIFI_DEBUG_PRINT is not set
+# default:
+CONFIG_ESP_WIFI_ENTERPRISE_SUPPORT=y
+# default:
+# CONFIG_ESP_WIFI_ENT_FREE_DYNAMIC_BUFFER is not set
+# default:
+# CONFIG_ESP_WIFI_PASSIVE_HIDDEN_AP_SUPPORT is not set
+# end of Wi-Fi
+
+#
+# Core dump
+#
+# default:
+# CONFIG_ESP_COREDUMP_ENABLE_TO_FLASH is not set
+# default:
+# CONFIG_ESP_COREDUMP_ENABLE_TO_UART is not set
+# default:
+CONFIG_ESP_COREDUMP_ENABLE_TO_NONE=y
+# end of Core dump
+
+#
+# FAT Filesystem support
+#
+# default:
+CONFIG_FATFS_VOLUME_COUNT=2
+# default:
+# CONFIG_FATFS_LFN_NONE is not set
+# default:
+CONFIG_FATFS_LFN_HEAP=y
+# default:
+# CONFIG_FATFS_LFN_STACK is not set
+# default:
+# CONFIG_FATFS_SECTOR_512 is not set
+# default:
+CONFIG_FATFS_SECTOR_4096=y
+# default:
+# CONFIG_FATFS_CODEPAGE_DYNAMIC is not set
+# default:
+CONFIG_FATFS_CODEPAGE_437=y
+# default:
+# CONFIG_FATFS_CODEPAGE_720 is not set
+# default:
+# CONFIG_FATFS_CODEPAGE_737 is not set
+# default:
+# CONFIG_FATFS_CODEPAGE_771 is not set
+# default:
+# CONFIG_FATFS_CODEPAGE_775 is not set
+# default:
+# CONFIG_FATFS_CODEPAGE_850 is not set
+# default:
+# CONFIG_FATFS_CODEPAGE_852 is not set
+# default:
+# CONFIG_FATFS_CODEPAGE_855 is not set
+# default:
+# CONFIG_FATFS_CODEPAGE_857 is not set
+# default:
+# CONFIG_FATFS_CODEPAGE_860 is not set
+# default:
+# CONFIG_FATFS_CODEPAGE_861 is not set
+# default:
+# CONFIG_FATFS_CODEPAGE_862 is not set
+# default:
+# CONFIG_FATFS_CODEPAGE_863 is not set
+# default:
+# CONFIG_FATFS_CODEPAGE_864 is not set
+# default:
+# CONFIG_FATFS_CODEPAGE_865 is not set
+# default:
+# CONFIG_FATFS_CODEPAGE_866 is not set
+# default:
+# CONFIG_FATFS_CODEPAGE_869 is not set
+# default:
+# CONFIG_FATFS_CODEPAGE_932 is not set
+# default:
+# CONFIG_FATFS_CODEPAGE_936 is not set
+# default:
+# CONFIG_FATFS_CODEPAGE_949 is not set
+# default:
+# CONFIG_FATFS_CODEPAGE_950 is not set
+# default:
+CONFIG_FATFS_CODEPAGE=437
+# default:
+CONFIG_FATFS_MAX_LFN=255
+# default:
+CONFIG_FATFS_API_ENCODING_ANSI_OEM=y
+# default:
+# CONFIG_FATFS_API_ENCODING_UTF_8 is not set
+# default:
+CONFIG_FATFS_FS_LOCK=0
+# default:
+CONFIG_FATFS_TIMEOUT_MS=10000
+# default:
+CONFIG_FATFS_PER_FILE_CACHE=y
+# default:
+# CONFIG_FATFS_USE_FASTSEEK is not set
+# default:
+CONFIG_FATFS_USE_STRFUNC_NONE=y
+# default:
+# CONFIG_FATFS_USE_STRFUNC_WITHOUT_CRLF_CONV is not set
+# default:
+# CONFIG_FATFS_USE_STRFUNC_WITH_CRLF_CONV is not set
+# default:
+CONFIG_FATFS_VFS_FSTAT_BLKSIZE=0
+# default:
+# CONFIG_FATFS_IMMEDIATE_FSYNC is not set
+# default:
+# CONFIG_FATFS_USE_LABEL is not set
+# default:
+CONFIG_FATFS_LINK_LOCK=y
+# default:
+CONFIG_FATFS_USE_DYN_BUFFERS=y
+
+#
+# File system free space calculation behavior
+#
+# default:
+CONFIG_FATFS_DONT_TRUST_FREE_CLUSTER_CNT=0
+# default:
+CONFIG_FATFS_DONT_TRUST_LAST_ALLOC=0
+# end of File system free space calculation behavior
+# end of FAT Filesystem support
+
+#
+# FreeRTOS
+#
+
+#
+# Kernel
+#
+# default:
+# CONFIG_FREERTOS_SMP is not set
+# default:
+# CONFIG_FREERTOS_UNICORE is not set
+# default:
+CONFIG_FREERTOS_HZ=100
+# default:
+# CONFIG_FREERTOS_CHECK_STACKOVERFLOW_NONE is not set
+# default:
+# CONFIG_FREERTOS_CHECK_STACKOVERFLOW_PTRVAL is not set
+# default:
+CONFIG_FREERTOS_CHECK_STACKOVERFLOW_CANARY=y
+# default:
+CONFIG_FREERTOS_THREAD_LOCAL_STORAGE_POINTERS=1
+# default:
+CONFIG_FREERTOS_IDLE_TASK_STACKSIZE=1536
+# default:
+# CONFIG_FREERTOS_USE_IDLE_HOOK is not set
+# default:
+# CONFIG_FREERTOS_USE_TICK_HOOK is not set
+# default:
+CONFIG_FREERTOS_MAX_TASK_NAME_LEN=16
+# default:
+# CONFIG_FREERTOS_ENABLE_BACKWARD_COMPATIBILITY is not set
+# default:
+CONFIG_FREERTOS_USE_TIMERS=y
+# default:
+CONFIG_FREERTOS_TIMER_SERVICE_TASK_NAME="Tmr Svc"
+# default:
+# CONFIG_FREERTOS_TIMER_TASK_AFFINITY_CPU0 is not set
+# default:
+# CONFIG_FREERTOS_TIMER_TASK_AFFINITY_CPU1 is not set
+# default:
+CONFIG_FREERTOS_TIMER_TASK_NO_AFFINITY=y
+# default:
+CONFIG_FREERTOS_TIMER_SERVICE_TASK_CORE_AFFINITY=0x7FFFFFFF
+# default:
+CONFIG_FREERTOS_TIMER_TASK_PRIORITY=1
+# default:
+CONFIG_FREERTOS_TIMER_TASK_STACK_DEPTH=2048
+# default:
+CONFIG_FREERTOS_TIMER_QUEUE_LENGTH=10
+# default:
+CONFIG_FREERTOS_QUEUE_REGISTRY_SIZE=0
+# default:
+CONFIG_FREERTOS_TASK_NOTIFICATION_ARRAY_ENTRIES=1
+# default:
+# CONFIG_FREERTOS_USE_TRACE_FACILITY is not set
+# default:
+# CONFIG_FREERTOS_USE_LIST_DATA_INTEGRITY_CHECK_BYTES is not set
+# default:
+# CONFIG_FREERTOS_GENERATE_RUN_TIME_STATS is not set
+# default:
+# CONFIG_FREERTOS_USE_APPLICATION_TASK_TAG is not set
+# end of Kernel
+
+#
+# Port
+#
+# default:
+CONFIG_FREERTOS_TASK_FUNCTION_WRAPPER=y
+# default:
+# CONFIG_FREERTOS_WATCHPOINT_END_OF_STACK is not set
+# default:
+CONFIG_FREERTOS_TLSP_DELETION_CALLBACKS=y
+# default:
+# CONFIG_FREERTOS_TASK_PRE_DELETION_HOOK is not set
+# default:
+CONFIG_FREERTOS_CHECK_MUTEX_GIVEN_BY_OWNER=y
+# default:
+CONFIG_FREERTOS_ISR_STACKSIZE=1536
+# default:
+CONFIG_FREERTOS_INTERRUPT_BACKTRACE=y
+# default:
+# CONFIG_FREERTOS_FPU_IN_ISR is not set
+# default:
+CONFIG_FREERTOS_TICK_SUPPORT_CORETIMER=y
+# default:
+CONFIG_FREERTOS_CORETIMER_0=y
+# default:
+# CONFIG_FREERTOS_CORETIMER_1 is not set
+# default:
+CONFIG_FREERTOS_SYSTICK_USES_CCOUNT=y
+# default:
+# CONFIG_FREERTOS_IN_IRAM is not set
+# default:
+# CONFIG_FREERTOS_CHECK_PORT_CRITICAL_COMPLIANCE is not set
+# end of Port
+
+#
+# Extra
+#
+# end of Extra
+
+# default:
+CONFIG_FREERTOS_PORT=y
+# default:
+CONFIG_FREERTOS_NO_AFFINITY=0x7FFFFFFF
+# default:
+CONFIG_FREERTOS_SUPPORT_STATIC_ALLOCATION=y
+# default:
+CONFIG_FREERTOS_DEBUG_OCDAWARE=y
+# default:
+CONFIG_FREERTOS_NUMBER_OF_CORES=2
+# end of FreeRTOS
+
+#
+# Hardware Abstraction Layer (HAL) and Low Level (LL)
+#
+# default:
+CONFIG_HAL_ASSERTION_EQUALS_SYSTEM=y
+# default:
+# CONFIG_HAL_ASSERTION_DISABLE is not set
+# default:
+# CONFIG_HAL_ASSERTION_SILENT is not set
+# default:
+# CONFIG_HAL_ASSERTION_ENABLE is not set
+# default:
+CONFIG_HAL_DEFAULT_ASSERTION_LEVEL=2
+# default:
+CONFIG_HAL_GPIO_USE_ROM_IMPL=y
+# end of Hardware Abstraction Layer (HAL) and Low Level (LL)
+
+#
+# Heap memory debugging
+#
+# default:
+CONFIG_HEAP_HAS_EXEC_HEAP=y
+# default:
+CONFIG_HEAP_POISONING_DISABLED=y
+# default:
+# CONFIG_HEAP_POISONING_LIGHT is not set
+# default:
+# CONFIG_HEAP_POISONING_COMPREHENSIVE is not set
+# default:
+CONFIG_HEAP_TRACING_OFF=y
+# default:
+# CONFIG_HEAP_TRACING_STANDALONE is not set
+# default:
+# CONFIG_HEAP_TRACING_TOHOST is not set
+# default:
+# CONFIG_HEAP_USE_HOOKS is not set
+# default:
+# CONFIG_HEAP_TASK_TRACKING is not set
+# default:
+# CONFIG_HEAP_ABORT_WHEN_ALLOCATION_FAILS is not set
+# default:
+# CONFIG_HEAP_PLACE_FUNCTION_INTO_FLASH is not set
+# end of Heap memory debugging
+
+#
+# Log
+#
+# default:
+CONFIG_LOG_VERSION_1=y
+# default:
+# CONFIG_LOG_VERSION_2 is not set
+# default:
+CONFIG_LOG_VERSION=1
+
+#
+# Log Level
+#
+# default:
+# CONFIG_LOG_DEFAULT_LEVEL_NONE is not set
+# default:
+# CONFIG_LOG_DEFAULT_LEVEL_ERROR is not set
+# default:
+# CONFIG_LOG_DEFAULT_LEVEL_WARN is not set
+# default:
+CONFIG_LOG_DEFAULT_LEVEL_INFO=y
+# default:
+# CONFIG_LOG_DEFAULT_LEVEL_DEBUG is not set
+# default:
+# CONFIG_LOG_DEFAULT_LEVEL_VERBOSE is not set
+# default:
+CONFIG_LOG_DEFAULT_LEVEL=3
+# default:
+CONFIG_LOG_MAXIMUM_EQUALS_DEFAULT=y
+# default:
+# CONFIG_LOG_MAXIMUM_LEVEL_DEBUG is not set
+# default:
+# CONFIG_LOG_MAXIMUM_LEVEL_VERBOSE is not set
+# default:
+CONFIG_LOG_MAXIMUM_LEVEL=3
+
+#
+# Level Settings
+#
+# default:
+# CONFIG_LOG_MASTER_LEVEL is not set
+# default:
+CONFIG_LOG_DYNAMIC_LEVEL_CONTROL=y
+# default:
+# CONFIG_LOG_TAG_LEVEL_IMPL_NONE is not set
+# default:
+# CONFIG_LOG_TAG_LEVEL_IMPL_LINKED_LIST is not set
+# default:
+CONFIG_LOG_TAG_LEVEL_IMPL_CACHE_AND_LINKED_LIST=y
+# default:
+# CONFIG_LOG_TAG_LEVEL_CACHE_ARRAY is not set
+# default:
+CONFIG_LOG_TAG_LEVEL_CACHE_BINARY_MIN_HEAP=y
+# default:
+CONFIG_LOG_TAG_LEVEL_IMPL_CACHE_SIZE=31
+# end of Level Settings
+# end of Log Level
+
+#
+# Format
+#
+# default:
+# CONFIG_LOG_COLORS is not set
+# default:
+CONFIG_LOG_TIMESTAMP_SOURCE_RTOS=y
+# default:
+# CONFIG_LOG_TIMESTAMP_SOURCE_SYSTEM is not set
+# end of Format
+
+#
+# Settings
+#
+# default:
+CONFIG_LOG_MODE_TEXT_EN=y
+# default:
+CONFIG_LOG_MODE_TEXT=y
+# end of Settings
+
+# default:
+CONFIG_LOG_IN_IRAM=y
+# end of Log
+
+#
+# LWIP
+#
+# default:
+CONFIG_LWIP_ENABLE=y
+# default:
+CONFIG_LWIP_LOCAL_HOSTNAME="espressif"
+# default:
+CONFIG_LWIP_TCPIP_TASK_PRIO=18
+# default:
+# CONFIG_LWIP_TCPIP_CORE_LOCKING is not set
+# default:
+# CONFIG_LWIP_CHECK_THREAD_SAFETY is not set
+# default:
+CONFIG_LWIP_DNS_SUPPORT_MDNS_QUERIES=y
+# default:
+# CONFIG_LWIP_L2_TO_L3_COPY is not set
+# default:
+# CONFIG_LWIP_IRAM_OPTIMIZATION is not set
+# default:
+# CONFIG_LWIP_EXTRA_IRAM_OPTIMIZATION is not set
+# default:
+CONFIG_LWIP_TIMERS_ONDEMAND=y
+# default:
+CONFIG_LWIP_ND6=y
+# default:
+# CONFIG_LWIP_FORCE_ROUTER_FORWARDING is not set
+# default:
+CONFIG_LWIP_MAX_SOCKETS=10
+# default:
+# CONFIG_LWIP_USE_ONLY_LWIP_SELECT is not set
+# default:
+# CONFIG_LWIP_SO_LINGER is not set
+# default:
+CONFIG_LWIP_SO_REUSE=y
+# default:
+CONFIG_LWIP_SO_REUSE_RXTOALL=y
+# default:
+# CONFIG_LWIP_SO_RCVBUF is not set
+# default:
+# CONFIG_LWIP_NETBUF_RECVINFO is not set
+# default:
+CONFIG_LWIP_IP_DEFAULT_TTL=64
+# default:
+CONFIG_LWIP_IP4_FRAG=y
+# default:
+CONFIG_LWIP_IP6_FRAG=y
+# default:
+# CONFIG_LWIP_IP4_REASSEMBLY is not set
+# default:
+# CONFIG_LWIP_IP6_REASSEMBLY is not set
+# default:
+CONFIG_LWIP_IP_REASS_MAX_PBUFS=10
+# default:
+CONFIG_LWIP_IPV6_DUP_DETECT_ATTEMPTS=1
+# default:
+# CONFIG_LWIP_IP_FORWARD is not set
+# default:
+# CONFIG_LWIP_STATS is not set
+# default:
+CONFIG_LWIP_ESP_GRATUITOUS_ARP=y
+# default:
+CONFIG_LWIP_GARP_TMR_INTERVAL=60
+# default:
+CONFIG_LWIP_ESP_MLDV6_REPORT=y
+# default:
+CONFIG_LWIP_MLDV6_TMR_INTERVAL=40
+# default:
+CONFIG_LWIP_TCPIP_RECVMBOX_SIZE=32
+# default:
+CONFIG_LWIP_DHCP_DOES_ARP_CHECK=y
+# default:
+# CONFIG_LWIP_DHCP_DOES_ACD_CHECK is not set
+# default:
+# CONFIG_LWIP_DHCP_DOES_NOT_CHECK_OFFERED_IP is not set
+# default:
+# CONFIG_LWIP_DHCP_DISABLE_CLIENT_ID is not set
+# default:
+CONFIG_LWIP_DHCP_DISABLE_VENDOR_CLASS_ID=y
+# default:
+# CONFIG_LWIP_DHCP_RESTORE_LAST_IP is not set
+# default:
+CONFIG_LWIP_DHCP_OPTIONS_LEN=69
+# default:
+CONFIG_LWIP_NUM_NETIF_CLIENT_DATA=0
+# default:
+CONFIG_LWIP_DHCP_COARSE_TIMER_SECS=1
+
+#
+# DHCP server
+#
+# default:
+CONFIG_LWIP_DHCPS=y
+# default:
+CONFIG_LWIP_DHCPS_REPORT_CLIENT_HOSTNAME=y
+# default:
+CONFIG_LWIP_DHCPS_LEASE_UNIT=60
+# default:
+CONFIG_LWIP_DHCPS_MAX_STATION_NUM=8
+# default:
+CONFIG_LWIP_DHCPS_MAX_HOSTNAME_LEN=64
+# default:
+CONFIG_LWIP_DHCPS_STATIC_ENTRIES=y
+# end of DHCP server
+
+# default:
+# CONFIG_LWIP_AUTOIP is not set
+# default:
+CONFIG_LWIP_IPV4=y
+# default:
+CONFIG_LWIP_IPV6=y
+# default:
+# CONFIG_LWIP_IPV6_AUTOCONFIG is not set
+# default:
+CONFIG_LWIP_IPV6_NUM_ADDRESSES=3
+# default:
+# CONFIG_LWIP_IPV6_FORWARD is not set
+# default:
+# CONFIG_LWIP_NETIF_STATUS_CALLBACK is not set
+# default:
+# CONFIG_LWIP_NETIF_LINK_CALLBACK is not set
+# default:
+CONFIG_LWIP_NETIF_LOOPBACK=y
+# default:
+CONFIG_LWIP_LOOPBACK_MAX_PBUFS=8
+
+#
+# TCP
+#
+# default:
+CONFIG_LWIP_MAX_ACTIVE_TCP=16
+# default:
+CONFIG_LWIP_MAX_LISTENING_TCP=16
+# default:
+CONFIG_LWIP_TCP_HIGH_SPEED_RETRANSMISSION=y
+# default:
+CONFIG_LWIP_TCP_MAXRTX=12
+# default:
+CONFIG_LWIP_TCP_SYNMAXRTX=12
+# default:
+CONFIG_LWIP_TCP_MSS=1440
+# default:
+CONFIG_LWIP_TCP_TMR_INTERVAL=250
+# default:
+CONFIG_LWIP_TCP_MSL=60000
+# default:
+CONFIG_LWIP_TCP_FIN_WAIT_TIMEOUT=20000
+# default:
+CONFIG_LWIP_TCP_SND_BUF_DEFAULT=5760
+# default:
+CONFIG_LWIP_TCP_WND_DEFAULT=5760
+# default:
+CONFIG_LWIP_TCP_RECVMBOX_SIZE=6
+# default:
+CONFIG_LWIP_TCP_ACCEPTMBOX_SIZE=6
+# default:
+CONFIG_LWIP_TCP_QUEUE_OOSEQ=y
+# default:
+CONFIG_LWIP_TCP_OOSEQ_TIMEOUT=6
+# default:
+CONFIG_LWIP_TCP_OOSEQ_MAX_PBUFS=4
+# default:
+# CONFIG_LWIP_TCP_SACK_OUT is not set
+# default:
+CONFIG_LWIP_TCP_OVERSIZE_MSS=y
+# default:
+# CONFIG_LWIP_TCP_OVERSIZE_QUARTER_MSS is not set
+# default:
+# CONFIG_LWIP_TCP_OVERSIZE_DISABLE is not set
+# default:
+CONFIG_LWIP_TCP_RTO_TIME=1500
+# end of TCP
+
+#
+# UDP
+#
+# default:
+CONFIG_LWIP_MAX_UDP_PCBS=16
+# default:
+CONFIG_LWIP_UDP_RECVMBOX_SIZE=6
+# end of UDP
+
+#
+# Checksums
+#
+# default:
+# CONFIG_LWIP_CHECKSUM_CHECK_IP is not set
+# default:
+# CONFIG_LWIP_CHECKSUM_CHECK_UDP is not set
+# default:
+CONFIG_LWIP_CHECKSUM_CHECK_ICMP=y
+# end of Checksums
+
+# default:
+CONFIG_LWIP_TCPIP_TASK_STACK_SIZE=3072
+# default:
+CONFIG_LWIP_TCPIP_TASK_AFFINITY_NO_AFFINITY=y
+# default:
+# CONFIG_LWIP_TCPIP_TASK_AFFINITY_CPU0 is not set
+# default:
+# CONFIG_LWIP_TCPIP_TASK_AFFINITY_CPU1 is not set
+# default:
+CONFIG_LWIP_TCPIP_TASK_AFFINITY=0x7FFFFFFF
+# default:
+CONFIG_LWIP_IPV6_MEMP_NUM_ND6_QUEUE=3
+# default:
+CONFIG_LWIP_IPV6_ND6_NUM_NEIGHBORS=5
+# default:
+CONFIG_LWIP_IPV6_ND6_NUM_PREFIXES=5
+# default:
+CONFIG_LWIP_IPV6_ND6_NUM_ROUTERS=3
+# default:
+CONFIG_LWIP_IPV6_ND6_NUM_DESTINATIONS=10
+# default:
+# CONFIG_LWIP_IPV6_ND6_ROUTE_INFO_OPTION_SUPPORT is not set
+# default:
+# CONFIG_LWIP_PPP_SUPPORT is not set
+# default:
+# CONFIG_LWIP_SLIP_SUPPORT is not set
+
+#
+# ICMP
+#
+# default:
+CONFIG_LWIP_ICMP=y
+# default:
+# CONFIG_LWIP_MULTICAST_PING is not set
+# default:
+# CONFIG_LWIP_BROADCAST_PING is not set
+# end of ICMP
+
+#
+# LWIP RAW API
+#
+# default:
+CONFIG_LWIP_MAX_RAW_PCBS=16
+# end of LWIP RAW API
+
+#
+# SNTP
+#
+# default:
+CONFIG_LWIP_SNTP_MAX_SERVERS=1
+# default:
+# CONFIG_LWIP_DHCP_GET_NTP_SRV is not set
+# default:
+CONFIG_LWIP_SNTP_UPDATE_DELAY=3600000
+# default:
+CONFIG_LWIP_SNTP_STARTUP_DELAY=y
+# default:
+CONFIG_LWIP_SNTP_MAXIMUM_STARTUP_DELAY=5000
+# end of SNTP
+
+#
+# DNS
+#
+# default:
+CONFIG_LWIP_DNS_MAX_HOST_IP=1
+# default:
+CONFIG_LWIP_DNS_MAX_SERVERS=3
+# default:
+# CONFIG_LWIP_FALLBACK_DNS_SERVER_SUPPORT is not set
+# default:
+# CONFIG_LWIP_DNS_SETSERVER_WITH_NETIF is not set
+# default:
+# CONFIG_LWIP_USE_ESP_GETADDRINFO is not set
+# end of DNS
+
+# default:
+CONFIG_LWIP_BRIDGEIF_MAX_PORTS=7
+# default:
+CONFIG_LWIP_ESP_LWIP_ASSERT=y
+
+#
+# Hooks
+#
+# default:
+# CONFIG_LWIP_HOOK_TCP_ISN_NONE is not set
+# default:
+CONFIG_LWIP_HOOK_TCP_ISN_DEFAULT=y
+# default:
+# CONFIG_LWIP_HOOK_TCP_ISN_CUSTOM is not set
+# default:
+CONFIG_LWIP_HOOK_IP6_ROUTE_NONE=y
+# default:
+# CONFIG_LWIP_HOOK_IP6_ROUTE_DEFAULT is not set
+# default:
+# CONFIG_LWIP_HOOK_IP6_ROUTE_CUSTOM is not set
+# default:
+CONFIG_LWIP_HOOK_ND6_GET_GW_NONE=y
+# default:
+# CONFIG_LWIP_HOOK_ND6_GET_GW_DEFAULT is not set
+# default:
+# CONFIG_LWIP_HOOK_ND6_GET_GW_CUSTOM is not set
+# default:
+CONFIG_LWIP_HOOK_IP6_SELECT_SRC_ADDR_NONE=y
+# default:
+# CONFIG_LWIP_HOOK_IP6_SELECT_SRC_ADDR_DEFAULT is not set
+# default:
+# CONFIG_LWIP_HOOK_IP6_SELECT_SRC_ADDR_CUSTOM is not set
+# default:
+CONFIG_LWIP_HOOK_DHCP_EXTRA_OPTION_NONE=y
+# default:
+# CONFIG_LWIP_HOOK_DHCP_EXTRA_OPTION_DEFAULT is not set
+# default:
+# CONFIG_LWIP_HOOK_DHCP_EXTRA_OPTION_CUSTOM is not set
+# default:
+CONFIG_LWIP_HOOK_NETCONN_EXT_RESOLVE_NONE=y
+# default:
+# CONFIG_LWIP_HOOK_NETCONN_EXT_RESOLVE_DEFAULT is not set
+# default:
+# CONFIG_LWIP_HOOK_NETCONN_EXT_RESOLVE_CUSTOM is not set
+# default:
+CONFIG_LWIP_HOOK_DNS_EXT_RESOLVE_NONE=y
+# default:
+# CONFIG_LWIP_HOOK_DNS_EXT_RESOLVE_CUSTOM is not set
+# default:
+# CONFIG_LWIP_HOOK_IP6_INPUT_NONE is not set
+# default:
+CONFIG_LWIP_HOOK_IP6_INPUT_DEFAULT=y
+# default:
+# CONFIG_LWIP_HOOK_IP6_INPUT_CUSTOM is not set
+# end of Hooks
+
+# default:
+# CONFIG_LWIP_DEBUG is not set
+# end of LWIP
+
+#
+# mbedTLS
+#
+
+#
+# Core Configuration
+#
+# default:
+CONFIG_MBEDTLS_VER_4_X_SUPPORT=y
+# default:
+# CONFIG_MBEDTLS_COMPILER_OPTIMIZATION_NONE is not set
+# default:
+CONFIG_MBEDTLS_COMPILER_OPTIMIZATION_SIZE=y
+# default:
+# CONFIG_MBEDTLS_COMPILER_OPTIMIZATION_PERF is not set
+# default:
+CONFIG_MBEDTLS_FS_IO=y
+# default:
+CONFIG_MBEDTLS_THREADING_C=y
+# default:
+# CONFIG_MBEDTLS_THREADING_ALT is not set
+# default:
+CONFIG_MBEDTLS_THREADING_PTHREAD=y
+# default:
+CONFIG_MBEDTLS_ERROR_STRINGS=y
+# default:
+CONFIG_MBEDTLS_VERSION_C=y
+# default:
+CONFIG_MBEDTLS_HAVE_TIME=y
+# default:
+# CONFIG_MBEDTLS_PLATFORM_TIME_ALT is not set
+# default:
+# CONFIG_MBEDTLS_HAVE_TIME_DATE is not set
+# default:
+CONFIG_MBEDTLS_INTERNAL_MEM_ALLOC=y
+# default:
+# CONFIG_MBEDTLS_DEFAULT_MEM_ALLOC is not set
+# default:
+# CONFIG_MBEDTLS_CUSTOM_MEM_ALLOC is not set
+# default:
+CONFIG_MBEDTLS_ASYMMETRIC_CONTENT_LEN=y
+# default:
+CONFIG_MBEDTLS_SSL_IN_CONTENT_LEN=16384
+# default:
+CONFIG_MBEDTLS_SSL_OUT_CONTENT_LEN=4096
+# default:
+# CONFIG_MBEDTLS_DYNAMIC_BUFFER is not set
+# default:
+# CONFIG_MBEDTLS_VERSION_FEATURES is not set
+# default:
+# CONFIG_MBEDTLS_DEBUG is not set
+# default:
+CONFIG_MBEDTLS_SELF_TEST=y
+# end of Core Configuration
+
+#
+# Certificates
+#
+# default:
+CONFIG_MBEDTLS_X509_USE_C=y
+# default:
+CONFIG_MBEDTLS_PEM_PARSE_C=y
+# default:
+CONFIG_MBEDTLS_PEM_WRITE_C=y
+# default:
+CONFIG_MBEDTLS_PK_C=y
+# default:
+CONFIG_MBEDTLS_PK_PARSE_C=y
+# default:
+CONFIG_MBEDTLS_PK_WRITE_C=y
+# default:
+# CONFIG_MBEDTLS_X509_REMOVE_INFO is not set
+# default:
+CONFIG_MBEDTLS_X509_CRL_PARSE_C=y
+# default:
+CONFIG_MBEDTLS_X509_CRT_PARSE_C=y
+# default:
+CONFIG_MBEDTLS_X509_CSR_PARSE_C=y
+# default:
+# CONFIG_MBEDTLS_X509_CREATE_C is not set
+# default:
+CONFIG_MBEDTLS_X509_RSASSA_PSS_SUPPORT=y
+# default:
+# CONFIG_MBEDTLS_X509_TRUSTED_CERT_CALLBACK is not set
+# default:
+CONFIG_MBEDTLS_ASN1_PARSE_C=y
+# default:
+CONFIG_MBEDTLS_ASN1_WRITE_C=y
+# default:
+CONFIG_MBEDTLS_CERTIFICATE_BUNDLE=y
+
+#
+# Certificate Bundle Configuration
+#
+# default:
+CONFIG_MBEDTLS_CERTIFICATE_BUNDLE_DEFAULT_FULL=y
+# default:
+# CONFIG_MBEDTLS_CERTIFICATE_BUNDLE_DEFAULT_CMN is not set
+# default:
+# CONFIG_MBEDTLS_CERTIFICATE_BUNDLE_DEFAULT_NONE is not set
+# default:
+# CONFIG_MBEDTLS_CUSTOM_CERTIFICATE_BUNDLE is not set
+# default:
+# CONFIG_MBEDTLS_CERTIFICATE_BUNDLE_DEPRECATED_LIST is not set
+# default:
+CONFIG_MBEDTLS_CERTIFICATE_BUNDLE_MAX_CERTS=200
+# end of Certificate Bundle Configuration
+
+# default:
+# CONFIG_MBEDTLS_ALLOW_WEAK_CERTIFICATE_VERIFICATION is not set
+# default:
+# CONFIG_MBEDTLS_CERTIFICATE_BUNDLE_CROSS_SIGNED_VERIFY is not set
+# end of Certificates
+
+# default:
+CONFIG_MBEDTLS_TLS_ENABLED=y
+
+#
+# TLS Protocol Configuration
+#
+# default:
+CONFIG_MBEDTLS_SSL_PROTO_TLS1_2=y
+# default:
+# CONFIG_MBEDTLS_SSL_PROTO_TLS1_3 is not set
+# default:
+# CONFIG_MBEDTLS_SSL_PROTO_GMTSSL1_1 is not set
+# default:
+CONFIG_MBEDTLS_TLS_SERVER=y
+# default:
+CONFIG_MBEDTLS_TLS_CLIENT=y
+# default:
+CONFIG_MBEDTLS_TLS_SERVER_AND_CLIENT=y
+# default:
+# CONFIG_MBEDTLS_TLS_SERVER_ONLY is not set
+# default:
+# CONFIG_MBEDTLS_TLS_CLIENT_ONLY is not set
+# default:
+# CONFIG_MBEDTLS_TLS_DISABLED is not set
+# default:
+# CONFIG_MBEDTLS_SSL_KEEP_PEER_CERTIFICATE is not set
+# default:
+# CONFIG_MBEDTLS_SSL_CONTEXT_SERIALIZATION is not set
+# default:
+CONFIG_MBEDTLS_SSL_CACHE_C=y
+# default:
+CONFIG_MBEDTLS_SSL_ALL_ALERT_MESSAGES=y
+
+#
+# TLS Key Exchange Configuration
+#
+# default:
+# CONFIG_MBEDTLS_PSK_MODES is not set
+# default:
+CONFIG_MBEDTLS_KEY_EXCHANGE_RSA=y
+# default:
+CONFIG_MBEDTLS_KEY_EXCHANGE_ELLIPTIC_CURVE=y
+# default:
+CONFIG_MBEDTLS_KEY_EXCHANGE_ECDHE_RSA=y
+# default:
+CONFIG_MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA=y
+# end of TLS Key Exchange Configuration
+
+# default:
+CONFIG_MBEDTLS_SSL_SERVER_NAME_INDICATION=y
+# default:
+CONFIG_MBEDTLS_SSL_ALPN=y
+# default:
+CONFIG_MBEDTLS_SSL_MAX_FRAGMENT_LENGTH=y
+# default:
+# CONFIG_MBEDTLS_SSL_VARIABLE_BUFFER_LENGTH is not set
+# default:
+CONFIG_MBEDTLS_SSL_RENEGOTIATION=y
+# default:
+CONFIG_MBEDTLS_CLIENT_SSL_SESSION_TICKETS=y
+# default:
+CONFIG_MBEDTLS_SERVER_SSL_SESSION_TICKETS=y
+# default:
+# CONFIG_MBEDTLS_SSL_KEYING_MATERIAL_EXPORT is not set
+# end of TLS Protocol Configuration
+
+# default:
+# CONFIG_MBEDTLS_SSL_PROTO_DTLS is not set
+
+#
+# Symmetric Ciphers
+#
+# default:
+CONFIG_MBEDTLS_AES_C=y
+# default:
+# CONFIG_MBEDTLS_CAMELLIA_C is not set
+# default:
+# CONFIG_MBEDTLS_ARIA_C is not set
+# default:
+# CONFIG_MBEDTLS_DES_C is not set
+# default:
+CONFIG_MBEDTLS_CCM_C=y
+# default:
+CONFIG_MBEDTLS_CIPHER_MODE_CBC=y
+# default:
+CONFIG_MBEDTLS_CIPHER_MODE_CFB=y
+# default:
+CONFIG_MBEDTLS_CIPHER_MODE_CTR=y
+# default:
+CONFIG_MBEDTLS_CIPHER_MODE_OFB=y
+# default:
+CONFIG_MBEDTLS_CIPHER_MODE_XTS=y
+# default:
+CONFIG_MBEDTLS_GCM_C=y
+# default:
+# CONFIG_MBEDTLS_NIST_KW_C is not set
+# default:
+CONFIG_MBEDTLS_AES_ROM_TABLES=y
+# default:
+# CONFIG_MBEDTLS_AES_FEWER_TABLES is not set
+# default:
+# CONFIG_MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH is not set
+# default:
+CONFIG_MBEDTLS_CMAC_C=y
+# end of Symmetric Ciphers
+
+#
+# Asymmetric Ciphers
+#
+# default:
+CONFIG_MBEDTLS_BIGNUM_C=y
+# default:
+CONFIG_MBEDTLS_RSA_C=y
+# default:
+CONFIG_MBEDTLS_ECP_C=y
+
+#
+# Supported Curves
+#
+# default:
+CONFIG_MBEDTLS_ECP_DP_SECP256R1_ENABLED=y
+# default:
+CONFIG_MBEDTLS_ECP_DP_SECP384R1_ENABLED=y
+# default:
+CONFIG_MBEDTLS_ECP_DP_SECP521R1_ENABLED=y
+# default:
+CONFIG_MBEDTLS_ECP_DP_SECP256K1_ENABLED=y
+# default:
+CONFIG_MBEDTLS_ECP_DP_BP256R1_ENABLED=y
+# default:
+CONFIG_MBEDTLS_ECP_DP_BP384R1_ENABLED=y
+# default:
+CONFIG_MBEDTLS_ECP_DP_BP512R1_ENABLED=y
+# default:
+CONFIG_MBEDTLS_ECP_DP_CURVE25519_ENABLED=y
+# end of Supported Curves
+
+#
+# Elliptic Curve Ciphers Configuration
+#
+# default:
+CONFIG_MBEDTLS_ECP_NIST_OPTIM=y
+# default:
+# CONFIG_MBEDTLS_ECP_FIXED_POINT_OPTIM is not set
+# default:
+# CONFIG_MBEDTLS_DHM_C is not set
+# default:
+CONFIG_MBEDTLS_ECDH_C=y
+# default:
+# CONFIG_MBEDTLS_ECJPAKE_C is not set
+# default:
+CONFIG_MBEDTLS_ECDSA_C=y
+# default:
+CONFIG_MBEDTLS_PK_PARSE_EC_EXTENDED=y
+# default:
+CONFIG_MBEDTLS_PK_PARSE_EC_COMPRESSED=y
+# default:
+CONFIG_MBEDTLS_ECDSA_DETERMINISTIC=y
+# default:
+# CONFIG_MBEDTLS_ECP_RESTARTABLE is not set
+# end of Elliptic Curve Ciphers Configuration
+# end of Asymmetric Ciphers
+
+#
+# Hash functions
+#
+# default:
+# CONFIG_MBEDTLS_RIPEMD160_C is not set
+# default:
+CONFIG_MBEDTLS_MD_C=y
+# default:
+CONFIG_MBEDTLS_MD5_C=y
+# default:
+CONFIG_MBEDTLS_SHA1_C=y
+# default:
+# CONFIG_MBEDTLS_SHA224_C is not set
+# default:
+CONFIG_MBEDTLS_SHA256_C=y
+# default:
+CONFIG_MBEDTLS_SHA384_C=y
+# default:
+CONFIG_MBEDTLS_SHA512_C=y
+# default:
+# CONFIG_MBEDTLS_SHA3_C is not set
+# default:
+CONFIG_MBEDTLS_ROM_MD5=y
+# end of Hash functions
+
+#
+# Hardware Acceleration
+#
+# default:
+CONFIG_MBEDTLS_HARDWARE_SHA=y
+# default:
+CONFIG_MBEDTLS_HARDWARE_MPI=y
+# default:
+CONFIG_MBEDTLS_LARGE_KEY_SOFTWARE_MPI=y
+# default:
+CONFIG_MBEDTLS_HARDWARE_AES=y
+# default:
+# CONFIG_MBEDTLS_AES_SOFT_FALLBACK is not set
+# default:
+CONFIG_MBEDTLS_GCM_SUPPORT_NON_AES_CIPHER=y
+# default:
+# CONFIG_MBEDTLS_ATCA_HW_ECDSA_SIGN is not set
+# default:
+# CONFIG_MBEDTLS_ATCA_HW_ECDSA_VERIFY is not set
+# end of Hardware Acceleration
+
+#
+# Entropy and Random Number Generation
+#
+# default:
+# CONFIG_MBEDTLS_ENTROPY_FORCE_SHA256 is not set
+# default:
+CONFIG_MBEDTLS_CTR_DRBG_C=y
+# default:
+CONFIG_MBEDTLS_HMAC_DRBG_C=y
+# end of Entropy and Random Number Generation
+
+#
+# Encoding/Decoding
+#
+# default:
+CONFIG_MBEDTLS_BASE64_C=y
+# default:
+CONFIG_MBEDTLS_PKCS5_C=y
+# default:
+CONFIG_MBEDTLS_PKCS7_C=y
+# default:
+CONFIG_MBEDTLS_PKCS1_V15=y
+# default:
+CONFIG_MBEDTLS_PKCS1_V21=y
+# end of Encoding/Decoding
+
+#
+# Stream Cipher
+#
+# default:
+# CONFIG_MBEDTLS_CHACHA20_C is not set
+# end of Stream Cipher
+# end of mbedTLS
+
+#
+# NVS
+#
+# default:
+# CONFIG_NVS_ASSERT_ERROR_CHECK is not set
+# default:
+# CONFIG_NVS_LEGACY_DUP_KEYS_COMPATIBILITY is not set
+# default:
+# CONFIG_NVS_BDL_STACK is not set
+# default:
+# CONFIG_NVS_FLASH_VERIFY_ERASE is not set
+# end of NVS
+
+#
+# OpenThread
+#
+# default:
+# CONFIG_OPENTHREAD_ENABLED is not set
+
+#
+# OpenThread Spinel
+#
+# default:
+# CONFIG_OPENTHREAD_SPINEL_ONLY is not set
+# end of OpenThread Spinel
+
+# default:
+# CONFIG_OPENTHREAD_DEBUG is not set
+# end of OpenThread
+
+#
+# Protocomm
+#
+# default:
+# CONFIG_ESP_PROTOCOMM_SUPPORT_SECURITY_VERSION_0 is not set
+# default:
+# CONFIG_ESP_PROTOCOMM_SUPPORT_SECURITY_VERSION_1 is not set
+# default:
+CONFIG_ESP_PROTOCOMM_SUPPORT_SECURITY_VERSION_2=y
+# default:
+CONFIG_ESP_PROTOCOMM_SUPPORT_SECURITY_PATCH_VERSION=y
+# end of Protocomm
+
+#
+# PThreads
+#
+# default:
+CONFIG_PTHREAD_TASK_PRIO_DEFAULT=5
+# default:
+CONFIG_PTHREAD_TASK_STACK_SIZE_DEFAULT=3072
+# default:
+CONFIG_PTHREAD_STACK_MIN=768
+# default:
+CONFIG_PTHREAD_DEFAULT_CORE_NO_AFFINITY=y
+# default:
+# CONFIG_PTHREAD_DEFAULT_CORE_0 is not set
+# default:
+# CONFIG_PTHREAD_DEFAULT_CORE_1 is not set
+# default:
+CONFIG_PTHREAD_TASK_CORE_DEFAULT=-1
+# default:
+CONFIG_PTHREAD_TASK_NAME_DEFAULT="pthread"
+# end of PThreads
+
+#
+# SD Protocol Layer Configuration
+#
+# default:
+CONFIG_SD_ENABLE_SDIO_SUPPORT=y
+# end of SD Protocol Layer Configuration
+
+#
+# MMU Config
+#
+# default:
+CONFIG_MMU_PAGE_SIZE_64KB=y
+# default:
+CONFIG_MMU_PAGE_MODE="64KB"
+# default:
+CONFIG_MMU_PAGE_SIZE=0x10000
+# end of MMU Config
+
+#
+# Main Flash configuration
+#
+
+#
+# SPI Flash behavior when brownout
+#
+# default:
+CONFIG_SPI_FLASH_BROWNOUT_RESET_XMC=y
+# default:
+CONFIG_SPI_FLASH_BROWNOUT_RESET=y
+# end of SPI Flash behavior when brownout
+
+#
+# Optional and Experimental Features (READ DOCS FIRST)
+#
+
+#
+# Features here require specific hardware (READ DOCS FIRST!)
+#
+# default:
+CONFIG_SPI_FLASH_SUSPEND_TSUS_VAL_US=50
+# default:
+# CONFIG_SPI_FLASH_FORCE_ENABLE_XMC_C_SUSPEND is not set
+# default:
+# CONFIG_SPI_FLASH_FORCE_ENABLE_C6_H2_SUSPEND is not set
+# default:
+CONFIG_SPI_FLASH_PLACE_FUNCTIONS_IN_IRAM=y
+# end of Optional and Experimental Features (READ DOCS FIRST)
+# end of Main Flash configuration
+
+#
+# SPI Flash driver
+#
+# default:
+# CONFIG_SPI_FLASH_VERIFY_WRITE is not set
+# default:
+# CONFIG_SPI_FLASH_ENABLE_COUNTERS is not set
+# default:
+CONFIG_SPI_FLASH_DANGEROUS_WRITE_ABORTS=y
+# default:
+# CONFIG_SPI_FLASH_DANGEROUS_WRITE_FAILS is not set
+# default:
+# CONFIG_SPI_FLASH_DANGEROUS_WRITE_ALLOWED is not set
+# default:
+# CONFIG_SPI_FLASH_SHARE_SPI1_BUS is not set
+# default:
+# CONFIG_SPI_FLASH_BYPASS_BLOCK_ERASE is not set
+# default:
+CONFIG_SPI_FLASH_YIELD_DURING_ERASE=y
+# default:
+CONFIG_SPI_FLASH_ERASE_YIELD_DURATION_MS=20
+# default:
+CONFIG_SPI_FLASH_ERASE_YIELD_TICKS=1
+# default:
+CONFIG_SPI_FLASH_WRITE_CHUNK_SIZE=8192
+# default:
+# CONFIG_SPI_FLASH_SIZE_OVERRIDE is not set
+# default:
+# CONFIG_SPI_FLASH_CHECK_ERASE_TIMEOUT_DISABLED is not set
+# default:
+# CONFIG_SPI_FLASH_OVERRIDE_CHIP_DRIVER_LIST is not set
+
+#
+# Auto-detect flash chips
+#
+# default:
+CONFIG_SPI_FLASH_VENDOR_XMC_SUPPORT_ENABLED=y
+# default:
+CONFIG_SPI_FLASH_VENDOR_GD_SUPPORT_ENABLED=y
+# default:
+CONFIG_SPI_FLASH_VENDOR_ISSI_SUPPORT_ENABLED=y
+# default:
+CONFIG_SPI_FLASH_VENDOR_MXIC_SUPPORT_ENABLED=y
+# default:
+CONFIG_SPI_FLASH_VENDOR_WINBOND_SUPPORT_ENABLED=y
+# default:
+CONFIG_SPI_FLASH_SUPPORT_ISSI_CHIP=y
+# default:
+CONFIG_SPI_FLASH_SUPPORT_MXIC_CHIP=y
+# default:
+CONFIG_SPI_FLASH_SUPPORT_GD_CHIP=y
+# default:
+CONFIG_SPI_FLASH_SUPPORT_WINBOND_CHIP=y
+# default:
+# CONFIG_SPI_FLASH_SUPPORT_BOYA_CHIP is not set
+# default:
+# CONFIG_SPI_FLASH_SUPPORT_TH_CHIP is not set
+# end of Auto-detect flash chips
+
+# default:
+CONFIG_SPI_FLASH_ENABLE_ENCRYPTED_READ_WRITE=y
+# end of SPI Flash driver
+
+#
+# SPIFFS Configuration
+#
+# default:
+CONFIG_SPIFFS_MAX_PARTITIONS=3
+
+#
+# SPIFFS Cache Configuration
+#
+# default:
+CONFIG_SPIFFS_CACHE=y
+# default:
+CONFIG_SPIFFS_CACHE_WR=y
+# default:
+# CONFIG_SPIFFS_CACHE_STATS is not set
+# end of SPIFFS Cache Configuration
+
+# default:
+CONFIG_SPIFFS_PAGE_CHECK=y
+# default:
+CONFIG_SPIFFS_GC_MAX_RUNS=10
+# default:
+# CONFIG_SPIFFS_GC_STATS is not set
+# default:
+CONFIG_SPIFFS_PAGE_SIZE=256
+# default:
+CONFIG_SPIFFS_OBJ_NAME_LEN=32
+# default:
+# CONFIG_SPIFFS_FOLLOW_SYMLINKS is not set
+# default:
+CONFIG_SPIFFS_USE_MAGIC=y
+# default:
+CONFIG_SPIFFS_USE_MAGIC_LENGTH=y
+# default:
+CONFIG_SPIFFS_META_LENGTH=4
+# default:
+CONFIG_SPIFFS_USE_MTIME=y
+
+#
+# Debug Configuration
+#
+# default:
+# CONFIG_SPIFFS_DBG is not set
+# default:
+# CONFIG_SPIFFS_API_DBG is not set
+# default:
+# CONFIG_SPIFFS_GC_DBG is not set
+# default:
+# CONFIG_SPIFFS_CACHE_DBG is not set
+# default:
+# CONFIG_SPIFFS_CHECK_DBG is not set
+# default:
+# CONFIG_SPIFFS_TEST_VISUALISATION is not set
+# end of Debug Configuration
+# end of SPIFFS Configuration
+
+#
+# TCP Transport
+#
+
+#
+# Websocket
+#
+# default:
+CONFIG_WS_TRANSPORT=y
+# default:
+CONFIG_WS_BUFFER_SIZE=1024
+# default:
+# CONFIG_WS_DYNAMIC_BUFFER is not set
+# end of Websocket
+# end of TCP Transport
+
+#
+# Ultra Low Power (ULP) Co-processor
+#
+# default:
+# CONFIG_ULP_COPROC_ENABLED is not set
+
+#
+# ULP Debugging Options
+#
+# end of ULP Debugging Options
+# end of Ultra Low Power (ULP) Co-processor
+
+#
+# Unity unit testing library
+#
+# default:
+CONFIG_UNITY_ENABLE_FLOAT=y
+# default:
+CONFIG_UNITY_ENABLE_DOUBLE=y
+# default:
+# CONFIG_UNITY_ENABLE_64BIT is not set
+# default:
+# CONFIG_UNITY_ENABLE_COLOR is not set
+# default:
+CONFIG_UNITY_ENABLE_IDF_TEST_RUNNER=y
+# default:
+# CONFIG_UNITY_ENABLE_FIXTURE is not set
+# default:
+# CONFIG_UNITY_ENABLE_BACKTRACE_ON_FAIL is not set
+# end of Unity unit testing library
+
+#
+# Virtual file system
+#
+# default:
+CONFIG_VFS_SUPPORT_IO=y
+# default:
+CONFIG_VFS_SUPPORT_DIR=y
+# default:
+CONFIG_VFS_SUPPORT_SELECT=y
+# default:
+CONFIG_VFS_SUPPRESS_SELECT_DEBUG_OUTPUT=y
+# default:
+# CONFIG_VFS_SELECT_IN_RAM is not set
+# default:
+# CONFIG_VFS_SUPPORT_TERMIOS is not set
+# default:
+CONFIG_VFS_MAX_COUNT=8
+# default:
+# CONFIG_VFS_SUPPRESS_CTX_DEPRECATION is not set
+
+#
+# Host File System I/O (Semihosting)
+#
+# default:
+CONFIG_VFS_SEMIHOSTFS_MAX_MOUNT_POINTS=1
+# end of Host File System I/O (Semihosting)
+
+# default:
+CONFIG_VFS_INITIALIZE_DEV_NULL=y
+# end of Virtual file system
+
+#
+# Wear Levelling
+#
+# default:
+# CONFIG_WL_SECTOR_SIZE_512 is not set
+# default:
+CONFIG_WL_SECTOR_SIZE_4096=y
+# default:
+CONFIG_WL_SECTOR_SIZE=4096
+# end of Wear Levelling
+# end of Component config
+
+# default:
+# CONFIG_IDF_EXPERIMENTAL_FEATURES is not set
+
+# Deprecated options for backward compatibility
+# CONFIG_APP_BUILD_TYPE_ELF_RAM is not set
+# CONFIG_NO_BLOBS is not set
+# CONFIG_ESP32_NO_BLOBS is not set
+# CONFIG_ESP32_COMPATIBLE_PRE_V2_1_BOOTLOADERS is not set
+# CONFIG_ESP32_COMPATIBLE_PRE_V3_1_BOOTLOADERS is not set
+# CONFIG_APP_ROLLBACK_ENABLE is not set
+# CONFIG_BOOTLOADER_COMPILER_OPTIMIZATION_NONE is not set
+# CONFIG_LOG_BOOTLOADER_LEVEL_NONE is not set
+# CONFIG_LOG_BOOTLOADER_LEVEL_ERROR is not set
+# CONFIG_LOG_BOOTLOADER_LEVEL_WARN is not set
+CONFIG_LOG_BOOTLOADER_LEVEL_INFO=y
+# CONFIG_LOG_BOOTLOADER_LEVEL_DEBUG is not set
+# CONFIG_LOG_BOOTLOADER_LEVEL_VERBOSE is not set
+CONFIG_LOG_BOOTLOADER_LEVEL=3
+# CONFIG_FLASH_ENCRYPTION_ENABLED is not set
+# CONFIG_FLASHMODE_QIO is not set
+# CONFIG_FLASHMODE_QOUT is not set
+CONFIG_FLASHMODE_DIO=y
+# CONFIG_FLASHMODE_DOUT is not set
+CONFIG_MONITOR_BAUD=115200
+CONFIG_OPTIMIZATION_LEVEL_DEBUG=y
+CONFIG_COMPILER_OPTIMIZATION_LEVEL_DEBUG=y
+CONFIG_COMPILER_OPTIMIZATION_DEFAULT=y
+# CONFIG_OPTIMIZATION_LEVEL_RELEASE is not set
+# CONFIG_COMPILER_OPTIMIZATION_LEVEL_RELEASE is not set
+CONFIG_OPTIMIZATION_ASSERTIONS_ENABLED=y
+# CONFIG_OPTIMIZATION_ASSERTIONS_SILENT is not set
+# CONFIG_OPTIMIZATION_ASSERTIONS_DISABLED is not set
+CONFIG_OPTIMIZATION_ASSERTION_LEVEL=2
+# CONFIG_CXX_EXCEPTIONS is not set
+CONFIG_STACK_CHECK_NONE=y
+# CONFIG_STACK_CHECK_NORM is not set
+# CONFIG_STACK_CHECK_STRONG is not set
+# CONFIG_STACK_CHECK_ALL is not set
+# CONFIG_WARN_WRITE_STRINGS is not set
+CONFIG_ADC_CAL_EFUSE_TP_ENABLE=y
+CONFIG_ADC_CAL_EFUSE_VREF_ENABLE=y
+CONFIG_ADC_CAL_LUT_ENABLE=y
+CONFIG_ADC_DISABLE_DAC=y
+# CONFIG_GPTIMER_ISR_IRAM_SAFE is not set
+# CONFIG_MCPWM_ISR_IRAM_SAFE is not set
+# CONFIG_EVENT_LOOP_PROFILING is not set
+CONFIG_POST_EVENTS_FROM_ISR=y
+CONFIG_POST_EVENTS_FROM_IRAM_ISR=y
+CONFIG_GDBSTUB_SUPPORT_TASKS=y
+CONFIG_GDBSTUB_MAX_TASKS=32
+# CONFIG_OTA_ALLOW_HTTP is not set
+# CONFIG_TWO_UNIVERSAL_MAC_ADDRESS is not set
+CONFIG_FOUR_UNIVERSAL_MAC_ADDRESS=y
+CONFIG_NUMBER_OF_UNIVERSAL_MAC_ADDRESS=4
+# CONFIG_ESP_SYSTEM_PD_FLASH is not set
+CONFIG_ESP32_DEEP_SLEEP_WAKEUP_DELAY=2000
+CONFIG_ESP_SLEEP_DEEP_SLEEP_WAKEUP_DELAY=2000
+CONFIG_ESP32_RTC_CLK_SRC_INT_RC=y
+CONFIG_ESP32_RTC_CLOCK_SOURCE_INTERNAL_RC=y
+# CONFIG_ESP32_RTC_CLK_SRC_EXT_CRYS is not set
+# CONFIG_ESP32_RTC_CLOCK_SOURCE_EXTERNAL_CRYSTAL is not set
+# CONFIG_ESP32_RTC_CLK_SRC_EXT_OSC is not set
+# CONFIG_ESP32_RTC_CLOCK_SOURCE_EXTERNAL_OSC is not set
+# CONFIG_ESP32_RTC_CLK_SRC_INT_8MD256 is not set
+# CONFIG_ESP32_RTC_CLOCK_SOURCE_INTERNAL_8MD256 is not set
+CONFIG_ESP32_RTC_CLK_CAL_CYCLES=1024
+CONFIG_PERIPH_CTRL_FUNC_IN_IRAM=y
+# CONFIG_ESP32_XTAL_FREQ_26 is not set
+CONFIG_ESP32_XTAL_FREQ_40=y
+# CONFIG_ESP32_XTAL_FREQ_AUTO is not set
+CONFIG_ESP32_XTAL_FREQ=40
+CONFIG_BROWNOUT_DET=y
+CONFIG_ESP32_BROWNOUT_DET=y
+CONFIG_BROWNOUT_DET_LVL_SEL_0=y
+CONFIG_ESP32_BROWNOUT_DET_LVL_SEL_0=y
+# CONFIG_BROWNOUT_DET_LVL_SEL_1 is not set
+# CONFIG_ESP32_BROWNOUT_DET_LVL_SEL_1 is not set
+# CONFIG_BROWNOUT_DET_LVL_SEL_2 is not set
+# CONFIG_ESP32_BROWNOUT_DET_LVL_SEL_2 is not set
+# CONFIG_BROWNOUT_DET_LVL_SEL_3 is not set
+# CONFIG_ESP32_BROWNOUT_DET_LVL_SEL_3 is not set
+# CONFIG_BROWNOUT_DET_LVL_SEL_4 is not set
+# CONFIG_ESP32_BROWNOUT_DET_LVL_SEL_4 is not set
+# CONFIG_BROWNOUT_DET_LVL_SEL_5 is not set
+# CONFIG_ESP32_BROWNOUT_DET_LVL_SEL_5 is not set
+# CONFIG_BROWNOUT_DET_LVL_SEL_6 is not set
+# CONFIG_ESP32_BROWNOUT_DET_LVL_SEL_6 is not set
+# CONFIG_BROWNOUT_DET_LVL_SEL_7 is not set
+# CONFIG_ESP32_BROWNOUT_DET_LVL_SEL_7 is not set
+CONFIG_BROWNOUT_DET_LVL=0
+CONFIG_ESP32_BROWNOUT_DET_LVL=0
+CONFIG_ESP_SYSTEM_BROWNOUT_INTR=y
+CONFIG_NEWLIB_STDOUT_LINE_ENDING_CRLF=y
+# CONFIG_NEWLIB_STDOUT_LINE_ENDING_LF is not set
+# CONFIG_NEWLIB_STDOUT_LINE_ENDING_CR is not set
+# CONFIG_NEWLIB_STDIN_LINE_ENDING_CRLF is not set
+# CONFIG_NEWLIB_STDIN_LINE_ENDING_LF is not set
+CONFIG_NEWLIB_STDIN_LINE_ENDING_CR=y
+CONFIG_NEWLIB_TIME_SYSCALL_USE_RTC_HRT=y
+CONFIG_ESP32_TIME_SYSCALL_USE_RTC_HRT=y
+CONFIG_ESP32_TIME_SYSCALL_USE_RTC_FRC1=y
+# CONFIG_NEWLIB_TIME_SYSCALL_USE_RTC is not set
+# CONFIG_ESP32_TIME_SYSCALL_USE_RTC is not set
+# CONFIG_NEWLIB_TIME_SYSCALL_USE_HRT is not set
+# CONFIG_ESP32_TIME_SYSCALL_USE_HRT is not set
+# CONFIG_ESP32_TIME_SYSCALL_USE_FRC1 is not set
+# CONFIG_NEWLIB_TIME_SYSCALL_USE_NONE is not set
+# CONFIG_ESP32_TIME_SYSCALL_USE_NONE is not set
+CONFIG_ESP32_PHY_CALIBRATION_AND_DATA_STORAGE=y
+# CONFIG_ESP32_PHY_INIT_DATA_IN_PARTITION is not set
+CONFIG_ESP32_PHY_MAX_WIFI_TX_POWER=20
+CONFIG_ESP32_PHY_MAX_TX_POWER=20
+# CONFIG_REDUCE_PHY_TX_POWER is not set
+# CONFIG_ESP32_REDUCE_PHY_TX_POWER is not set
+# CONFIG_SPIRAM_SUPPORT is not set
+# CONFIG_ESP32_SPIRAM_SUPPORT is not set
+CONFIG_CONSOLE_UART_DEFAULT=y
+# CONFIG_CONSOLE_UART_CUSTOM is not set
+# CONFIG_CONSOLE_UART_NONE is not set
+# CONFIG_ESP_CONSOLE_UART_NONE is not set
+CONFIG_CONSOLE_UART=y
+CONFIG_CONSOLE_UART_NUM=0
+CONFIG_CONSOLE_UART_BAUDRATE=115200
+# CONFIG_ESP32_DEFAULT_CPU_FREQ_80 is not set
+CONFIG_ESP32_DEFAULT_CPU_FREQ_160=y
+# CONFIG_ESP32_DEFAULT_CPU_FREQ_240 is not set
+CONFIG_ESP32_DEFAULT_CPU_FREQ_MHZ=160
+CONFIG_TRACEMEM_RESERVE_DRAM=0x0
+# CONFIG_ESP32_PANIC_PRINT_HALT is not set
+CONFIG_ESP32_PANIC_PRINT_REBOOT=y
+# CONFIG_ESP32_PANIC_SILENT_REBOOT is not set
+# CONFIG_ESP32_PANIC_GDBSTUB is not set
+CONFIG_SYSTEM_EVENT_QUEUE_SIZE=32
+CONFIG_SYSTEM_EVENT_TASK_STACK_SIZE=2304
+CONFIG_MAIN_TASK_STACK_SIZE=3584
+CONFIG_INT_WDT=y
+CONFIG_INT_WDT_TIMEOUT_MS=300
+CONFIG_INT_WDT_CHECK_CPU1=y
+CONFIG_TASK_WDT=y
+CONFIG_ESP_TASK_WDT=y
+# CONFIG_TASK_WDT_PANIC is not set
+CONFIG_TASK_WDT_TIMEOUT_S=5
+CONFIG_TASK_WDT_CHECK_IDLE_TASK_CPU0=y
+CONFIG_TASK_WDT_CHECK_IDLE_TASK_CPU1=y
+# CONFIG_ESP32_DEBUG_STUBS_ENABLE is not set
+CONFIG_ESP32_DEBUG_OCDAWARE=y
+# CONFIG_DISABLE_BASIC_ROM_CONSOLE is not set
+CONFIG_IPC_TASK_STACK_SIZE=1024
+CONFIG_TIMER_TASK_STACK_SIZE=3584
+# CONFIG_ESP32_APPTRACE_ENABLE is not set
+CONFIG_ESP32_WIFI_ENABLED=y
+CONFIG_ESP32_WIFI_STATIC_RX_BUFFER_NUM=10
+CONFIG_ESP32_WIFI_DYNAMIC_RX_BUFFER_NUM=32
+# CONFIG_ESP32_WIFI_STATIC_TX_BUFFER is not set
+CONFIG_ESP32_WIFI_DYNAMIC_TX_BUFFER=y
+CONFIG_ESP32_WIFI_TX_BUFFER_TYPE=1
+CONFIG_ESP32_WIFI_DYNAMIC_TX_BUFFER_NUM=32
+# CONFIG_ESP32_WIFI_CSI_ENABLED is not set
+CONFIG_ESP32_WIFI_AMPDU_TX_ENABLED=y
+CONFIG_ESP32_WIFI_TX_BA_WIN=6
+CONFIG_ESP32_WIFI_AMPDU_RX_ENABLED=y
+CONFIG_ESP32_WIFI_RX_BA_WIN=6
+CONFIG_ESP32_WIFI_NVS_ENABLED=y
+CONFIG_ESP32_WIFI_TASK_PINNED_TO_CORE_0=y
+# CONFIG_ESP32_WIFI_TASK_PINNED_TO_CORE_1 is not set
+CONFIG_ESP32_WIFI_SOFTAP_BEACON_MAX_LEN=752
+CONFIG_ESP32_WIFI_MGMT_SBUF_NUM=32
+CONFIG_ESP32_WIFI_IRAM_OPT=y
+CONFIG_ESP32_WIFI_RX_IRAM_OPT=y
+CONFIG_ESP32_WIFI_ENABLE_WPA3_SAE=y
+CONFIG_ESP32_WIFI_ENABLE_WPA3_OWE_STA=y
+# CONFIG_ESP_WIFI_NAN_ENABLE is not set
+CONFIG_WPA_MBEDTLS_CRYPTO=y
+CONFIG_WPA_MBEDTLS_TLS_CLIENT=y
+# CONFIG_WPA_WAPI_PSK is not set
+# CONFIG_WPA_11KV_SUPPORT is not set
+# CONFIG_WPA_MBO_SUPPORT is not set
+# CONFIG_WPA_DPP_SUPPORT is not set
+# CONFIG_WPA_11R_SUPPORT is not set
+# CONFIG_WPA_WPS_SOFTAP_REGISTRAR is not set
+# CONFIG_WPA_WPS_STRICT is not set
+# CONFIG_WPA_DEBUG_PRINT is not set
+# CONFIG_ESP32_ENABLE_COREDUMP_TO_FLASH is not set
+# CONFIG_ESP32_ENABLE_COREDUMP_TO_UART is not set
+CONFIG_ESP32_ENABLE_COREDUMP_TO_NONE=y
+CONFIG_TIMER_TASK_PRIORITY=1
+CONFIG_TIMER_TASK_STACK_DEPTH=2048
+CONFIG_TIMER_QUEUE_LENGTH=10
+# CONFIG_ENABLE_STATIC_TASK_CLEAN_UP_HOOK is not set
+# CONFIG_HAL_ASSERTION_SILIENT is not set
+# CONFIG_L2_TO_L3_COPY is not set
+CONFIG_ESP_GRATUITOUS_ARP=y
+CONFIG_GARP_TMR_INTERVAL=60
+CONFIG_TCPIP_RECVMBOX_SIZE=32
+CONFIG_TCP_MAXRTX=12
+CONFIG_TCP_SYNMAXRTX=12
+CONFIG_TCP_MSS=1440
+CONFIG_TCP_MSL=60000
+CONFIG_TCP_SND_BUF_DEFAULT=5760
+CONFIG_TCP_WND_DEFAULT=5760
+CONFIG_TCP_RECVMBOX_SIZE=6
+CONFIG_TCP_QUEUE_OOSEQ=y
+CONFIG_TCP_OVERSIZE_MSS=y
+# CONFIG_TCP_OVERSIZE_QUARTER_MSS is not set
+# CONFIG_TCP_OVERSIZE_DISABLE is not set
+CONFIG_UDP_RECVMBOX_SIZE=6
+CONFIG_TCPIP_TASK_STACK_SIZE=3072
+CONFIG_TCPIP_TASK_AFFINITY_NO_AFFINITY=y
+# CONFIG_TCPIP_TASK_AFFINITY_CPU0 is not set
+# CONFIG_TCPIP_TASK_AFFINITY_CPU1 is not set
+CONFIG_TCPIP_TASK_AFFINITY=0x7FFFFFFF
+# CONFIG_PPP_SUPPORT is not set
+CONFIG_ESP32_PTHREAD_TASK_PRIO_DEFAULT=5
+CONFIG_ESP32_PTHREAD_TASK_STACK_SIZE_DEFAULT=3072
+CONFIG_ESP32_PTHREAD_STACK_MIN=768
+CONFIG_ESP32_DEFAULT_PTHREAD_CORE_NO_AFFINITY=y
+# CONFIG_ESP32_DEFAULT_PTHREAD_CORE_0 is not set
+# CONFIG_ESP32_DEFAULT_PTHREAD_CORE_1 is not set
+CONFIG_ESP32_PTHREAD_TASK_CORE_DEFAULT=-1
+CONFIG_ESP32_PTHREAD_TASK_NAME_DEFAULT="pthread"
+CONFIG_SPI_FLASH_WRITING_DANGEROUS_REGIONS_ABORTS=y
+# CONFIG_SPI_FLASH_WRITING_DANGEROUS_REGIONS_FAILS is not set
+# CONFIG_SPI_FLASH_WRITING_DANGEROUS_REGIONS_ALLOWED is not set
+# CONFIG_ESP32_ULP_COPROC_ENABLED is not set
+CONFIG_SUPPRESS_SELECT_DEBUG_OUTPUT=y
+# CONFIG_SUPPORT_TERMIOS is not set
+CONFIG_SEMIHOSTFS_MAX_MOUNT_POINTS=1
+# End of deprecated options

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -1,0 +1,11 @@
+version: 2.3.3
+name: DCCEXProtocol
+description: "DCCEXProtocol library for ESP-IDF"
+dependencies:
+  idf:
+    version: '>=5.5.1'
+targets:
+  - esp32
+  - esp32s2
+  - esp32s3
+  - esp32c3

--- a/src/DCCEXCSConsist.h
+++ b/src/DCCEXCSConsist.h
@@ -24,7 +24,7 @@
 #define DCCEXCSCONSIST_H
 
 #include "DCCEXLoco.h"
-#include <Arduino.h>
+#include <string.h>
 
 /**
  * @brief Structure for a CSConsistMember

--- a/src/DCCEXInbound.cpp
+++ b/src/DCCEXInbound.cpp
@@ -33,12 +33,13 @@
 // The dump() function is used to list the parameters obtained.
 // so this is the best place to look for how to access the results.
 #include "DCCEXInbound.h"
-#include <Arduino.h>
+#include <stdlib.h>
+#include <string.h>
 
 // Internal stuff for the parser and getters.
 const int32_t QUOTE_FLAG = 0x77777000;
 const int32_t QUOTE_FLAG_AREA = 0xFFFFF000;
-enum splitState : byte {
+enum splitState : uint8_t {
   FIND_START,
   SET_OPCODE,
   SKIP_SPACES,
@@ -50,7 +51,7 @@ enum splitState : byte {
 
 int16_t DCCEXInbound::_maxParams = 0;
 int16_t DCCEXInbound::_parameterCount = 0;
-byte DCCEXInbound::_opcode = 0;
+uint8_t DCCEXInbound::_opcode = 0;
 int32_t *DCCEXInbound::_parameterValues = nullptr;
 char *DCCEXInbound::_cmdBuffer = nullptr;
 
@@ -70,7 +71,7 @@ void DCCEXInbound::cleanup() {
   }
 }
 
-byte DCCEXInbound::getOpcode() { return _opcode; }
+uint8_t DCCEXInbound::getOpcode() { return _opcode; }
 
 int16_t DCCEXInbound::getParameterCount() { return _parameterCount; }
 
@@ -116,7 +117,7 @@ bool DCCEXInbound::parse(char *command) {
   splitState state = FIND_START;
 
   while (_parameterCount < _maxParams) {
-    byte hot = *remainingCmd;
+    uint8_t hot = *remainingCmd;
     if (hot == 0)
       return false; // no > on end of command.
 
@@ -199,6 +200,7 @@ bool DCCEXInbound::parse(char *command) {
   return false; // we ran out of max parameters
 }
 
+#ifdef ARDUINO
 void DCCEXInbound::dump(Print *out) {
   out->print(F("\nDCCEXInbound Opcode='"));
   if (_opcode)
@@ -222,7 +224,7 @@ void DCCEXInbound::dump(Print *out) {
     }
   }
 }
-
+#endif
 // Private methods
 
 bool DCCEXInbound::_isTextInternal(int16_t n) { return ((_parameterValues[n] & QUOTE_FLAG_AREA) == QUOTE_FLAG); }

--- a/src/DCCEXInbound.h
+++ b/src/DCCEXInbound.h
@@ -30,6 +30,9 @@
 #ifndef DCCEXINBOUND_H
 #define DCCEXINBOUND_H
 
+#ifdef ARDUINO
+#include <Arduino.h>
+#endif
 #include <inttypes.h>
 
 /* How to use this:

--- a/src/DCCEXInbound.h
+++ b/src/DCCEXInbound.h
@@ -30,7 +30,7 @@
 #ifndef DCCEXINBOUND_H
 #define DCCEXINBOUND_H
 
-#include <Arduino.h>
+#include <inttypes.h>
 
 /* How to use this:
   1) setup is done once with your expected max parameter count.
@@ -58,7 +58,7 @@ public:
   static bool parse(char *command);
 
   /// @brief Gets the DCC-EX OPCODE of the parsed command (the first char after the <)
-  static byte getOpcode();
+  static uint8_t getOpcode();
 
   /// @brief Gets number of parameters detected after OPCODE  <JR 1 2 3> is 4 parameters!
   /// @return Number of parameters
@@ -86,12 +86,14 @@ public:
 
   /// @brief dump list of parameters obtained
   /// @param out Address of output e.g. &Serial
+#ifdef ARDUINO  
   static void dump(Print *);
+#endif  
 
 private:
   static int16_t _maxParams;
   static int16_t _parameterCount;
-  static byte _opcode;
+  static uint8_t _opcode;
   static int32_t *_parameterValues;
   static char *_cmdBuffer;
   static bool _isTextInternal(int16_t n);

--- a/src/DCCEXLoco.cpp
+++ b/src/DCCEXLoco.cpp
@@ -28,7 +28,10 @@
  */
 
 #include "DCCEXLoco.h"
-#include <Arduino.h>
+#include <cstdio>
+#include <string.h>
+#include <stdlib.h>
+#include <numeric>
 
 // class Loco
 // Public methods
@@ -333,9 +336,9 @@ void Consist::addLoco(int address, Facing facing) {
   if (_locoCount == 0) {
     facing = FacingForward;
     if (_name == nullptr) {
-      int addressLength = (address == 0) ? 1 : log10(address) + 1;
+      int addressLength = snprintf(nullptr, 0, "%d", address);
       char *newName = new char[addressLength + 1];
-      itoa(address, newName, 10);
+      snprintf(newName, addressLength + 1, "%d", address);
       setName(newName);
       delete[] newName;
     }

--- a/src/DCCEXLoco.h
+++ b/src/DCCEXLoco.h
@@ -30,7 +30,7 @@
 #ifndef DCCEXLOCO_H
 #define DCCEXLOCO_H
 
-#include <Arduino.h>
+#include <inttypes.h>
 
 static const int MAX_FUNCTIONS = 32;
 const int MAX_OBJECT_NAME_LENGTH = 30;      // including Loco name, Turnout/Point names, Route names, etc. names

--- a/src/DCCEXProtocol.cpp
+++ b/src/DCCEXProtocol.cpp
@@ -41,6 +41,10 @@ Function/method prefixes
 
 #include "DCCEXProtocol.h"
 #include <ctype.h>
+#include <stdlib.h>
+#include <cstdio>
+#include <ctype.h>
+#include <string.h>
 
 static const int MIN_SPEED = 0;
 static const int MAX_SPEED = 126;
@@ -1578,7 +1582,7 @@ void DCCEXProtocol::_cmdAppend(const char *s) {
 
 void DCCEXProtocol::_cmdAppend(int n) {
   char buf[12]; // Enough for -2147483648
-  itoa(n, buf, 10);
+  snprintf(buf, sizeof(buf), "%d", n);
   _cmdAppend(buf);
 }
 

--- a/src/DCCEXProtocol.cpp
+++ b/src/DCCEXProtocol.cpp
@@ -40,6 +40,7 @@ Function/method prefixes
 */
 
 #include "DCCEXProtocol.h"
+#include <ctype.h>
 
 static const int MIN_SPEED = 0;
 static const int MAX_SPEED = 126;
@@ -762,7 +763,7 @@ void DCCEXProtocol::_init() {
   memset(_inputBuffer, 0, sizeof(_inputBuffer));
   _nextChar = 0;
   // last Response time
-  _lastServerResponseTime = millis();
+  _lastServerResponseTime = DCCEX_MILLIS();
 }
 
 void DCCEXProtocol::_sendCommand() {
@@ -772,14 +773,14 @@ void DCCEXProtocol::_sendCommand() {
       _console->print("==> ");
       _console->println(_outboundCommand);
     }
-    *_outboundCommand = 0;     // clear it once it has been sent
-    _lastHeartbeat = millis(); // If we sent a command, a heartbeat isn't necessary
+    *_outboundCommand = 0;           // clear it once it has been sent
+    _lastHeartbeat = DCCEX_MILLIS(); // If we sent a command, a heartbeat isn't necessary
   }
 }
 
 void DCCEXProtocol::_processCommand() {
   // last Response time
-  _lastServerResponseTime = millis();
+  _lastServerResponseTime = DCCEX_MILLIS();
 
   switch (DCCEXInbound::getOpcode()) {
   case '@': // Screen update
@@ -980,8 +981,8 @@ void DCCEXProtocol::_processScreenUpdate() { //<@ screen row "message">
 }
 
 void DCCEXProtocol::_sendHeartbeat() {
-  if (millis() - _lastHeartbeat > _heartbeatDelay) {
-    _lastHeartbeat = millis();
+  if (DCCEX_MILLIS() - _lastHeartbeat > _heartbeatDelay) {
+    _lastHeartbeat = DCCEX_MILLIS();
     _sendOpcode('#');
   }
 }
@@ -1069,8 +1070,8 @@ void DCCEXProtocol::_processReadResponse() { // <r id> - -1 = error
 }
 
 void DCCEXProtocol::_processPendingUserChanges() {
-  if (millis() - _lastUserChange > _userChangeDelay) {
-    _lastUserChange = millis();
+  if (DCCEX_MILLIS() - _lastUserChange > _userChangeDelay) {
+    _lastUserChange = DCCEX_MILLIS();
     _setLocos(Loco::getFirst());
     _setLocos(Loco::getFirstLocalLoco());
   }

--- a/src/DCCEXProtocol.h
+++ b/src/DCCEXProtocol.h
@@ -45,7 +45,23 @@ Version information: MOVED TO DCCEXProtocolVersion.h
 #include "DCCEXRoutes.h"
 #include "DCCEXTurnouts.h"
 #include "DCCEXTurntables.h"
-#include <Arduino.h>
+#include "DCCMillisWrappers.h"
+#ifdef ARDUINO
+  #include <Arduino.h>
+#else
+#include <DCCStream.h>
+#endif
+#include <stddef.h>
+
+// Platform-neutral time source. Override this macro in non-Arduino builds, for example:
+// -DDCCEX_MILLIS()=my_platform_millis()
+#ifndef DCCEX_MILLIS
+  #ifdef DCCEX_DEFAULT_MILLIS
+    #define DCCEX_MILLIS() DCCEX_DEFAULT_MILLIS()
+  #else
+    #define DCCEX_MILLIS() millis()
+  #endif
+#endif
 
 const int MAX_OUTBOUND_COMMAND_LENGTH = 100; // Max number of bytes for outbound commands
 
@@ -79,7 +95,7 @@ public:
 
   /// @brief Dummy availability check
   /// @return Returns false (0) always
-  int available() { return 0; }
+  int available() const { return 0; }
 
   /// @brief Dummy flush method
   void flush() {}

--- a/src/DCCEXProtocol.h
+++ b/src/DCCEXProtocol.h
@@ -49,7 +49,7 @@ Version information: MOVED TO DCCEXProtocolVersion.h
 #ifdef ARDUINO
   #include <Arduino.h>
 #else
-#include <DCCStream.h>
+#include "DCCStream.h"
 #endif
 #include <stddef.h>
 

--- a/src/DCCEXProtocol.h
+++ b/src/DCCEXProtocol.h
@@ -95,7 +95,7 @@ public:
 
   /// @brief Dummy availability check
   /// @return Returns false (0) always
-  int available() const { return 0; }
+  int available() { return 0; }
 
   /// @brief Dummy flush method
   void flush() {}

--- a/src/DCCEXProtocolVersion.h
+++ b/src/DCCEXProtocolVersion.h
@@ -29,11 +29,12 @@
 #ifndef DCCEXPROTOCOLVERSION_H
 #define DCCEXPROTOCOLVERSION_H
 
-#define DCCEX_PROTOCOL_VERSION "1.3.2"
+#define DCCEX_PROTOCOL_VERSION "1.3.3"
 
 /*
 Version information:
 
+1.3.3   - Allow using ESP-IDF and Pico C/CPP SDK without Arduino.
 1.3.2   - Add missing getSpeed() and getDirection() to CSConsist class
 1.3.1   - Fix bug where function 28 is masked off incorrectly and not received in Loco updates
 1.3.0   - Introduce queued throttle updates to prevent buffer overloads and broadcast storms

--- a/src/DCCEXRoutes.cpp
+++ b/src/DCCEXRoutes.cpp
@@ -27,7 +27,7 @@
  */
 
 #include "DCCEXRoutes.h"
-#include <Arduino.h>
+#include <string.h>
 
 // Public methods
 

--- a/src/DCCEXRoutes.h
+++ b/src/DCCEXRoutes.h
@@ -29,7 +29,6 @@
 #ifndef DCCEXROUTES_H
 #define DCCEXROUTES_H
 
-#include <Arduino.h>
 
 enum RouteType {
   RouteTypeRoute = 'R',

--- a/src/DCCEXTurnouts.cpp
+++ b/src/DCCEXTurnouts.cpp
@@ -27,7 +27,7 @@
  */
 
 #include "DCCEXTurnouts.h"
-#include <Arduino.h>
+#include <string.h>
 
 Turnout *Turnout::_first = nullptr;
 

--- a/src/DCCEXTurnouts.h
+++ b/src/DCCEXTurnouts.h
@@ -29,8 +29,6 @@
 #ifndef DCCEXTURNOUTS_H
 #define DCCEXTURNOUTS_H
 
-#include <Arduino.h>
-
 /// @brief Class to contain and maintain the various Turnout/Point attributes and methods
 class Turnout {
 public:

--- a/src/DCCEXTurntables.cpp
+++ b/src/DCCEXTurntables.cpp
@@ -27,7 +27,7 @@
  */
 
 #include "DCCEXTurntables.h"
-#include <Arduino.h>
+#include <string.h>
 
 // class TurntableIndex
 

--- a/src/DCCEXTurntables.h
+++ b/src/DCCEXTurntables.h
@@ -29,8 +29,6 @@
 #ifndef DCCEXTURNTABLES_H
 #define DCCEXTURNTABLES_H
 
-#include <Arduino.h>
-
 enum TurntableType {
   TurntableTypeDCC = 0,
   TurntableTypeEXTT = 1,

--- a/src/DCCMillisWrappers.h
+++ b/src/DCCMillisWrappers.h
@@ -28,6 +28,14 @@
       return (unsigned long)to_ms_since_boot(get_absolute_time());
     }
     #define DCCEX_DEFAULT_MILLIS() dccex_pico_millis()
+  #elif defined(__linux__) && !defined(ARDUINO)
+    #include <chrono>
+    static inline unsigned long dccex_linux_millis() {
+      const auto now = std::chrono::steady_clock::now();
+      static const auto start = now;
+      return (unsigned long)std::chrono::duration_cast<std::chrono::milliseconds>(now - start).count();
+    }
+    #define DCCEX_DEFAULT_MILLIS() dccex_linux_millis()
   #endif
 
 #endif

--- a/src/DCCMillisWrappers.h
+++ b/src/DCCMillisWrappers.h
@@ -1,0 +1,35 @@
+/* -*- c++ -*- */
+
+#ifndef DCC_MILLIS_WRAPPERS_H
+#define DCC_MILLIS_WRAPPERS_H
+
+/*
+ * Optional platform wrappers for time-in-milliseconds.
+ *
+ * This header defines DCCEX_DEFAULT_MILLIS() when it can detect a supported
+ * platform. If your platform is not detected, define DCCEX_MILLIS() in your
+ * build flags or before including DCCEXProtocol.h.
+ */
+
+#if !defined(DCCEX_DEFAULT_MILLIS)
+
+  #if defined(ARDUINO)
+    #include <Arduino.h>
+    #define DCCEX_DEFAULT_MILLIS() millis()
+  #elif defined(ESP_PLATFORM)
+    #include <esp_timer.h>
+    static inline unsigned long dccex_esp_idf_millis() {
+      return (unsigned long)(esp_timer_get_time() / 1000ULL);
+    }
+    #define DCCEX_DEFAULT_MILLIS() dccex_esp_idf_millis()
+  #elif defined(PICO_SDK_VERSION_MAJOR) || defined(PICO_RP2040) || defined(PICO_ON_DEVICE)
+    #include <pico/time.h>
+    static inline unsigned long dccex_pico_millis() {
+      return (unsigned long)to_ms_since_boot(get_absolute_time());
+    }
+    #define DCCEX_DEFAULT_MILLIS() dccex_pico_millis()
+  #endif
+
+#endif
+
+#endif

--- a/src/DCCStream.h
+++ b/src/DCCStream.h
@@ -1,0 +1,23 @@
+#ifndef _STREAM_H
+#define _STREAM_H
+
+#ifndef ARDUINO 
+
+#include <stddef.h>
+#include <inttypes.h>
+
+class Stream {
+  public:
+    virtual ~Stream() {}
+
+    virtual int available() const = 0;
+    virtual int read() = 0;
+    virtual size_t write(const uint8_t *buffer, size_t size) = 0;
+    virtual void flush() = 0;
+    virtual void println(const char* format, ...) {};
+    virtual void print(const char* format, ...) {};
+};
+
+#endif
+
+#endif

--- a/src/DCCStream.h
+++ b/src/DCCStream.h
@@ -10,7 +10,7 @@ class Stream {
   public:
     virtual ~Stream() {}
 
-    virtual int available() const = 0;
+    virtual int available() = 0;
     virtual int read() = 0;
     virtual size_t write(const uint8_t *buffer, size_t size) = 0;
     virtual void flush() = 0;

--- a/test/mocks/Arduino.h
+++ b/test/mocks/Arduino.h
@@ -28,6 +28,8 @@
 #include <gmock/gmock.h>
 #include <stdint.h>
 
+#define ARDUINO
+
 // Define states
 #define HIGH 0x1
 #define LOW 0x0

--- a/test/setup/TurnoutTests.h
+++ b/test/setup/TurnoutTests.h
@@ -27,7 +27,7 @@
  */
 
 #ifndef TURNOUTTESTS_H
-#define TUNROUTTESTS_H
+#define TURNOUTTESTS_H
 
 #include "TestHarnessBase.hpp"
 

--- a/test/test_General/test_Infrastructure.cpp
+++ b/test/test_General/test_Infrastructure.cpp
@@ -50,4 +50,4 @@ TEST_F(DCCEXProtocolTests, testGenericSendCommand) {
 /**
  * @brief Test the library version can be retrieved via the static method
  */
-TEST_F(DCCEXProtocolTests, TestLibraryVersion) { ASSERT_STREQ(DCCEXProtocol::getLibraryVersion(), "1.3.2"); }
+TEST_F(DCCEXProtocolTests, TestLibraryVersion) { ASSERT_STREQ(DCCEXProtocol::getLibraryVersion(), "1.3.3"); }

--- a/test/test_Loco/test_Loco.cpp
+++ b/test/test_Loco/test_Loco.cpp
@@ -271,6 +271,9 @@ TEST_F(LocoTests, TestGetByAddress) {
   Loco *loco3 = new Loco(3, LocoSource::LocoSourceEntry);
   Loco *loco42 = new Loco(42, LocoSource::LocoSourceRoster);
 
+  ASSERT_NE(loco3, nullptr);
+  ASSERT_NE(loco42, nullptr);
+
   // Assert both are now available
   ASSERT_NE(Loco::getByAddress(42), nullptr);
   ASSERT_NE(Loco::getByAddress(3), nullptr);


### PR DESCRIPTION
This should be better, can now run the examples without any changes to the initial library.

Have added code for changing millis for Arduino, ESP-IDF, Pico, Linux.
Added a override for Stream, which is used when not using Arduino.

Setup tests so they can be used with platformio, or the google test setup via cmake.

Added an example of the loco-controller example which shows the basic setup for esp-idf.

