### PR TITLE
JMRI Sensors

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=DCCEXProtocol
-version=1.3.3
+version=1.4.0
 author=Peter Cole, Peter Akers <akersp62@gmail.com>
 maintainer=Peter Cole, Peter Akers <akersp62@gmail.com>
 sentence=DCC-EX Native Protocol implementation

--- a/src/DCCEXProtocol.cpp
+++ b/src/DCCEXProtocol.cpp
@@ -1189,8 +1189,6 @@ void DCCEXProtocol::_getRoster() {
   _rosterRequested = true;
 }
 
-bool DCCEXProtocol::_requestedRoster() { return _rosterRequested; }
-
 void DCCEXProtocol::_processRosterList() {
   if (roster != nullptr) { // already have a roster so this is an update
     return;
@@ -1242,8 +1240,6 @@ void DCCEXProtocol::_getTurnouts() {
   _sendOneParam('J', 'T');
   _turnoutListRequested = true;
 }
-
-bool DCCEXProtocol::_requestedTurnouts() { return _turnoutListRequested; }
 
 void DCCEXProtocol::_processTurnoutList() {
   // <jT id1 id2 id3 ...>
@@ -1316,8 +1312,6 @@ void DCCEXProtocol::_getRoutes() {
   _routeListRequested = true;
 }
 
-bool DCCEXProtocol::_requestedRoutes() { return _routeListRequested; }
-
 void DCCEXProtocol::_processRouteList() {
   if (routes != nullptr) {
     return;
@@ -1368,8 +1362,6 @@ void DCCEXProtocol::_getTurntables() {
   _sendOneParam('J', 'O');
   _turntableListRequested = true;
 }
-
-bool DCCEXProtocol::_requestedTurntables() { return _turntableListRequested; }
 
 void DCCEXProtocol::_processTurntableList() { // <jO [id1 id2 id3 ...]>
   if (turntables != nullptr) {                // already have a turntables list so this is an update

--- a/src/DCCEXProtocol.cpp
+++ b/src/DCCEXProtocol.cpp
@@ -782,6 +782,8 @@ void DCCEXProtocol::setFastClock(int minutes, int speedFactor) {
 
 void DCCEXProtocol::requestFastClockTime() { _sendOneParam('J', 'C'); }
 
+void DCCEXProtocol::requestJMRISensorList() { _sendOpcode('Q'); }
+
 // Private methods
 // Protocol and server methods
 
@@ -839,6 +841,13 @@ void DCCEXProtocol::_processCommand() {
     if (DCCEXInbound::isTextParameter(0) || DCCEXInbound::getParameterCount() > 2)
       break;
     _processTrackPower();
+    break;
+
+  case 'Q': // JMRI sensor activated
+  case 'q': // JMRI sensor deactivated
+    if (DCCEXInbound::getParameterCount() == 1 && !DCCEXInbound::isTextParameter(0)) {
+      _processJMRISensorBroadcast(DCCEXInbound::getOpcode());
+    }
     break;
 
   case '=': // Track type broadcast
@@ -1583,6 +1592,19 @@ void DCCEXProtocol::_processFastClockTime() { // <jC minutes>
     return;
 
   _delegate->receivedFastClockTime(DCCEXInbound::getNumber(1));
+}
+
+// JMRI sensor methods
+void DCCEXProtocol::_processJMRISensorBroadcast(byte opcode) { // <Q|q id>
+  if (!_delegate)
+    return;
+
+  int id = DCCEXInbound::getNumber(0);
+
+  if (id < 1)
+    return;
+
+  _delegate->receivedJMRISensorBroadcast(id, opcode == 'Q' ? JMRISensorState::Activated : JMRISensorState::Deactivated);
 }
 
 // Helper methods to build the outbound command

--- a/src/DCCEXProtocol.h
+++ b/src/DCCEXProtocol.h
@@ -71,6 +71,12 @@ enum MomentumAlgorithm {
   Power,  // Speed difference
 };
 
+// Valid JMRI sensor states
+enum JMRISensorState {
+  Activated,
+  Deactivated,
+};
+
 /// @brief Nullstream class for initial DCCEXProtocol instantiation to direct streams to nothing
 class NullStream : public Stream {
 public:
@@ -229,6 +235,13 @@ public:
    * @param minutes Time in minutes
    */
   virtual void receivedFastClockTime(int minutes) {}
+
+  /**
+   * @brief Notify when a JMRI sensor broadcast has been received
+   * @param id ID of the JMRI sensor
+   * @param state JMRISensorState enum value
+   */
+  virtual void receivedJMRISensorBroadcast(int id, JMRISensorState state) {}
 
   /// @brief Default destructor for DCCEXProtocolDelegate
   virtual ~DCCEXProtocolDelegate() = default;
@@ -793,6 +806,13 @@ public:
    */
   void requestFastClockTime();
 
+  // JMRI Sensor Methods
+
+  /**
+   * @brief Request the list of JMRI sensors
+   */
+  void requestJMRISensorList();
+
   // Attributes
 
   /// @brief Linked list of Loco objects to form the roster, call roster->getFirst()
@@ -886,6 +906,9 @@ private:
   // Fast clock methods
   void _processSetFastClock();
   void _processFastClockTime();
+
+  // JMRI sensor methods
+  void _processJMRISensorBroadcast(byte opcode);
 
   // Attributes
   int _rosterCount = 0;                               // Count of roster items received

--- a/src/DCCEXProtocol.h
+++ b/src/DCCEXProtocol.h
@@ -861,14 +861,12 @@ private:
 
   // Roster methods
   void _getRoster();
-  bool _requestedRoster();
   void _processRosterList();
   void _requestRosterEntry(int address);
   void _processRosterEntry();
 
   // Turnout methods
   void _getTurnouts();
-  bool _requestedTurnouts();
   void _processTurnoutList();
   void _requestTurnoutEntry(int id);
   void _processTurnoutEntry();
@@ -876,14 +874,12 @@ private:
 
   // Route methods
   void _getRoutes();
-  bool _requestedRoutes();
   void _processRouteList();
   void _requestRouteEntry(int id);
   void _processRouteEntry();
 
   // Turntable methods
   void _getTurntables();
-  bool _requestedTurntables();
   void _processTurntableList();
   void _requestTurntableEntry(int id);
   void _processTurntableEntry();

--- a/src/DCCEXProtocolVersion.h
+++ b/src/DCCEXProtocolVersion.h
@@ -29,11 +29,14 @@
 #ifndef DCCEXPROTOCOLVERSION_H
 #define DCCEXPROTOCOLVERSION_H
 
-#define DCCEX_PROTOCOL_VERSION "1.3.3"
+#define DCCEX_PROTOCOL_VERSION "1.4.0"
 
 /*
 Version information:
 
+1.4.0   - Add JMRI type sensor support for broadcasts, noting objects are not created:
+                - requestJMRISensorList()
+        - DCCEXProtocolDelegate new method receivedJMRISensorBroadcast(int id, JMRISensorState state)
 1.3.3   - Bug fixes and expanded test coverage, no functional library changes:
         - Fix CSConsist::removeMember() member count bug when removing an address not in the consist
         - Fix new Route objects not defaulting to RouteTypeRoute until setType() was called

--- a/test/mocks/MockDCCEXProtocolDelegate.h
+++ b/test/mocks/MockDCCEXProtocolDelegate.h
@@ -71,4 +71,7 @@ public:
 
   // Notify when a fast clock time has been received
   MOCK_METHOD(void, receivedFastClockTime, (int minutes), (override));
+
+  // Notify when a JMRI sensor broadcast has been received
+  MOCK_METHOD(void, receivedJMRISensorBroadcast, (int id, JMRISensorState state), (override));
 };

--- a/test/setup/JMRISensorTests.h
+++ b/test/setup/JMRISensorTests.h
@@ -1,0 +1,36 @@
+/* -*- c++ -*-
+ *
+ * DCCEXProtocol
+ *
+ * This package implements a DCCEX native protocol connection,
+ * allow a device to communicate with a DCC-EX EX-CommandStation.
+ *
+ * Copyright © 2026 Peter Cole
+ *
+ * This work is licensed under the Creative Commons Attribution-ShareAlike
+ * 4.0 International License. To view a copy of this license, visit
+ * http://creativecommons.org/licenses/by-sa/4.0/ or send a letter to
+ * Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.
+ *
+ * Attribution — You must give appropriate credit, provide a link to the
+ * license, and indicate if changes were made. You may do so in any
+ * reasonable manner, but not in any way that suggests the licensor
+ * endorses you or your use.
+ *
+ * ShareAlike — If you remix, transform, or build upon the material, you
+ * must distribute your contributions under the same license as the
+ * original.
+ *
+ * All other rights reserved.
+ *
+ */
+
+#ifndef JMRISENSORTESTS_H
+#define JMRISENSORTESTS_H
+
+#include "TestHarnessBase.hpp"
+
+/// @brief Test harness for Loco and associated classes
+class JMRISensorTests : public TestHarnessBase {};
+
+#endif // JMRISENSORTESTS_H

--- a/test/test_CSConsists/test_CSConsistClass.cpp
+++ b/test/test_CSConsists/test_CSConsistClass.cpp
@@ -166,6 +166,22 @@ TEST_F(CSConsistTests, TestCallingWithInvalidParams) {
 }
 
 /**
+ * @brief Test adding a member with an invalid address is ignored
+ */
+TEST_F(CSConsistTests, TestAddMemberInvalidAddress) {
+  // Create the consist
+  CSConsist *csConsist = new CSConsist();
+
+  // Negative and over-range addresses must be ignored
+  csConsist->addMember(-1, false);
+  csConsist->addMember(10240, true);
+
+  // No members should have been added
+  EXPECT_EQ(csConsist->getMemberCount(), 0);
+  EXPECT_EQ(csConsist->getFirstMember(), nullptr);
+}
+
+/**
  * @brief Test removing a member by address
  */
 TEST_F(CSConsistTests, TestRemoveMemberByAddress) {

--- a/test/test_CSConsists/test_CSConsistParsing.cpp
+++ b/test/test_CSConsists/test_CSConsistParsing.cpp
@@ -250,3 +250,32 @@ TEST_F(CSConsistTests, TestMemberShuffles) {
   EXPECT_EQ(CSConsist::getMemberCSConsist(20), csConsist1);
   EXPECT_EQ(CSConsist::getMemberCSConsist(30), csConsist1);
 }
+
+/**
+ * @brief Test a consist update for the same lead loco reuses the existing CSConsist
+ */
+TEST_F(CSConsistTests, TestUpdateExistingConsist) {
+  // Receive an initial consist
+  EXPECT_CALL(_delegate, receivedCSConsist(42, _)).Times(1);
+  _stream << "<^ 42 -24 3>";
+  _dccexProtocol.check();
+
+  CSConsist *csConsist = CSConsist::getFirst();
+  ASSERT_NE(csConsist, nullptr);
+  EXPECT_EQ(csConsist->getMemberCount(), 3);
+
+  // A second consist with the same lead loco must update, not duplicate
+  EXPECT_CALL(_delegate, receivedCSConsist(42, _)).Times(1);
+  _stream << "<^ 42 -5 25>";
+  _dccexProtocol.check();
+
+  // The same CSConsist object is reused with the new members
+  EXPECT_EQ(CSConsist::getFirst(), csConsist);
+  EXPECT_EQ(csConsist->getMemberCount(), 3);
+  EXPECT_EQ(csConsist->getFirstMember()->address, 42);
+  EXPECT_TRUE(csConsist->isInConsist(5));
+  EXPECT_TRUE(csConsist->isReversed(5));
+  EXPECT_TRUE(csConsist->isInConsist(25));
+  EXPECT_FALSE(csConsist->isInConsist(24));
+  EXPECT_FALSE(csConsist->isInConsist(3));
+}

--- a/test/test_General/test_InboundParsing.cpp
+++ b/test/test_General/test_InboundParsing.cpp
@@ -87,3 +87,12 @@ TEST_F(DCCEXProtocolTests, lowercaseKeywordHandling) {
   EXPECT_CALL(_delegate, receivedTrackType('A', TrackManagerMode::MAIN, 0)).Times(Exactly(1));
   _dccexProtocol.check();
 }
+
+/**
+ * @brief Ensure an underscore keyword is hashed like other keywords
+ */
+TEST_F(DCCEXProtocolTests, underscoreKeywordHandling) {
+  char command[] = "<1 _>";
+  EXPECT_TRUE(DCCEXInbound::parse(command));
+  EXPECT_EQ(DCCEXInbound::getNumber(0), 0x5F);
+}

--- a/test/test_General/test_Infrastructure.cpp
+++ b/test/test_General/test_Infrastructure.cpp
@@ -90,7 +90,7 @@ TEST_F(DCCEXProtocolTests, TestSendNullCommand) {
 /**
  * @brief Test the library version can be retrieved via the static method
  */
-TEST_F(DCCEXProtocolTests, TestLibraryVersion) { ASSERT_STREQ(DCCEXProtocol::getLibraryVersion(), "1.3.3"); }
+TEST_F(DCCEXProtocolTests, TestLibraryVersion) { ASSERT_STREQ(DCCEXProtocol::getLibraryVersion(), "1.4.0"); }
 
 /**
  * @brief Test calling disconnect() is a no-op and does not crash

--- a/test/test_General/test_MalformedInput.cpp
+++ b/test/test_General/test_MalformedInput.cpp
@@ -165,3 +165,65 @@ TEST_F(DCCEXProtocolTests, locoBroadcastFunctionMapMasked) {
   EXPECT_CALL(_delegate, receivedLocoBroadcast(5, 0, Reverse, 0)).Times(Exactly(1));
   _dccexProtocol.check();
 }
+
+/**
+ * @brief Test screen update not called with a numeric instead of text parameter
+ */
+TEST_F(DCCEXProtocolTests, screenUpdateNumericMessageDropped) {
+  _stream << "<@ 1 1 2>";
+  EXPECT_CALL(_delegate, receivedScreenUpdate(_, _, _)).Times(0);
+  _dccexProtocol.check();
+  EXPECT_EQ(_stream.getOutput(), "");
+}
+
+/**
+ * @brief Test screen update not called with too many parameters
+ */
+TEST_F(DCCEXProtocolTests, screenUpdateTooManyParamsDropped) {
+  _stream << "<@ 1 1 \"x\" \"y\">";
+  EXPECT_CALL(_delegate, receivedScreenUpdate(_, _, _)).Times(0);
+  _dccexProtocol.check();
+  EXPECT_EQ(_stream.getOutput(), "");
+}
+
+/**
+ * @brief Test turntable broadcast not called with an invalid parameter count
+ */
+TEST_F(DCCEXProtocolTests, turntableBroadcastBadParamCountDropped) {
+  _stream << "<I 1 1>";
+  EXPECT_CALL(_delegate, receivedTurntableAction(_, _, _)).Times(0);
+  _dccexProtocol.check();
+  EXPECT_EQ(_stream.getOutput(), "");
+}
+
+/**
+ * @brief Test message broadcast not called with a numeric parameter
+ */
+TEST_F(DCCEXProtocolTests, messageBroadcastNumericParamDropped) {
+  _stream << "<m 123>";
+  EXPECT_CALL(_delegate, receivedMessage(_)).Times(0);
+  _dccexProtocol.check();
+  EXPECT_EQ(_stream.getOutput(), "");
+}
+
+/**
+ * @brief Test unknown throttle subcommand ignored
+ */
+TEST_F(DCCEXProtocolTests, unknownThrottleSubcommandIgnored) {
+  EXPECT_NO_FATAL_FAILURE({
+    _stream << "<jX 1>";
+    _dccexProtocol.check();
+  });
+  EXPECT_EQ(_stream.getOutput(), "");
+}
+
+/**
+ * @brief Test invalid fast clock param count is ignored
+ */
+TEST_F(DCCEXProtocolTests, fastClockBadParamCountIgnored) {
+  _stream << "<jC>";
+  EXPECT_CALL(_delegate, receivedFastClockTime(_)).Times(0);
+  EXPECT_CALL(_delegate, receivedSetFastClock(_, _)).Times(0);
+  _dccexProtocol.check();
+  EXPECT_EQ(_stream.getOutput(), "");
+}

--- a/test/test_General/test_TrackPowerParsing.cpp
+++ b/test/test_General/test_TrackPowerParsing.cpp
@@ -52,3 +52,12 @@ TEST_F(DCCEXProtocolTests, mainTrackOff) {
   EXPECT_CALL(_delegate, receivedTrackPower(TrackPower::PowerOff)).Times(Exactly(1));
   _dccexProtocol.check();
 }
+
+/**
+ * @brief Test receiving an unknown power state leaves the state as PowerUnknown
+ */
+TEST_F(DCCEXProtocolTests, unknownPowerState) {
+  _stream << "<p2>";
+  EXPECT_CALL(_delegate, receivedTrackPower(TrackPower::PowerUnknown)).Times(Exactly(1));
+  _dccexProtocol.check();
+}

--- a/test/test_JMRISensor/test_JMRISensor.cpp
+++ b/test/test_JMRISensor/test_JMRISensor.cpp
@@ -1,0 +1,90 @@
+/* -*- c++ -*-
+ *
+ * Copyright © 2026 Peter Cole
+ *
+ * This work is licensed under the Creative Commons Attribution-ShareAlike
+ * 4.0 International License. To view a copy of this license, visit
+ * http://creativecommons.org/licenses/by-sa/4.0/ or send a letter to
+ * Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.
+ *
+ * Attribution — You must give appropriate credit, provide a link to the
+ * license, and indicate if changes were made. You may do so in any
+ * reasonable manner, but not in any way that suggests the licensor
+ * endorses you or your use.
+ *
+ * ShareAlike — If you remix, transform, or build upon the material, you
+ * must distribute your contributions under the same license as the
+ * original.
+ *
+ * All other rights reserved.
+ *
+ */
+
+#include "../setup/JMRISensorTests.h"
+
+/**
+ * @brief Test requesting the JMRI sensor list method
+ */
+TEST_F(JMRISensorTests, requestJMRISensorList) {
+  // Request should send "<Q>" only
+  _dccexProtocol.requestJMRISensorList();
+  EXPECT_EQ(_stream.getOutput(), "<Q>");
+  _stream.clearOutput();
+}
+
+/**
+ * @brief Test receiving a JMRI sensor activated broadcast calls the delegate method
+ */
+TEST_F(JMRISensorTests, receiveJMRISensorActivated) {
+  // Receiving "<Q 100>" should call the delegate with sensor ID 100 activated
+  EXPECT_CALL(_delegate, receivedJMRISensorBroadcast(100, JMRISensorState::Activated)).Times(Exactly(1));
+  _stream << "<Q 100>";
+  _dccexProtocol.check();
+}
+
+/**
+ * @brief Test receiving a JMRI sensor deactivated broadcast calls the delegate method
+ */
+TEST_F(JMRISensorTests, receiveJMRISensorDeactivated) {
+  // Receiving "<q 200>" should call the delegate with sensor ID 200 deactivated
+  EXPECT_CALL(_delegate, receivedJMRISensorBroadcast(200, JMRISensorState::Deactivated)).Times(Exactly(1));
+  _stream << "<q 200>";
+  _dccexProtocol.check();
+}
+
+/**
+ * @brief Test receiving a broadcast with no params is ignored
+ */
+TEST_F(JMRISensorTests, receiveJMRISensorBroadcastNoParams) {
+  // "<Q>" is the outbound request form, must not trigger a broadcast callback
+  _stream << "<Q>";
+  EXPECT_CALL(_delegate, receivedJMRISensorBroadcast(_, _)).Times(Exactly(0));
+  _dccexProtocol.check();
+}
+
+/**
+ * @brief Test receiving too many parameters is ignored
+ */
+TEST_F(JMRISensorTests, receiveJMRISensorBroadcastTooManyParams) {
+  _stream << "<Q 100 200>";
+  EXPECT_CALL(_delegate, receivedJMRISensorBroadcast(_, _)).Times(Exactly(0));
+  _dccexProtocol.check();
+}
+
+/**
+ * @brief Test receiving an invalid parameter is ignored
+ */
+TEST_F(JMRISensorTests, receiveJMRISensorBroadcastTextParam) {
+  _stream << "<Q \"abc\">";
+  EXPECT_CALL(_delegate, receivedJMRISensorBroadcast(_, _)).Times(Exactly(0));
+  _dccexProtocol.check();
+}
+
+/**
+ * @brief Test receiving invalid sensor ID is ignored
+ */
+TEST_F(JMRISensorTests, receiveJMRISensorBroadcastIdZero) {
+  EXPECT_CALL(_delegate, receivedJMRISensorBroadcast(_, _)).Times(Exactly(0));
+  _stream << "<Q 0>";
+  _dccexProtocol.check();
+}

--- a/test/test_Loco/test_RosterParsing.cpp
+++ b/test/test_Loco/test_RosterParsing.cpp
@@ -197,3 +197,20 @@ TEST_F(LocoTests, refreshRosterResetsAndReRequests) {
   _dccexProtocol.getLists(true, false, false, false);
   EXPECT_EQ(_stream.getOutput(), "<J R>");
 }
+
+/**
+ * @brief Test a roster entry for an address not in the roster is accepted without requesting details
+ */
+TEST_F(LocoTests, parseRosterEntryUnknownAddress) {
+  EXPECT_FALSE(_dccexProtocol.receivedRoster());
+
+  // Detailed response for an unknown address
+  _stream << R"(<jR 999 "Loco999" "Func999">)";
+  EXPECT_CALL(_delegate, receivedRosterList()).Times(Exactly(1));
+  _dccexProtocol.check();
+
+  // The roster is received, nothing is created, and no entry details are requested
+  EXPECT_TRUE(_dccexProtocol.receivedRoster());
+  EXPECT_EQ(_dccexProtocol.getRosterCount(), 0);
+  EXPECT_EQ(_stream.getOutput(), "");
+}

--- a/test/test_NoDelegate/test_NoDelegate.cpp
+++ b/test/test_NoDelegate/test_NoDelegate.cpp
@@ -331,3 +331,15 @@ TEST_F(TestHarnessNoDelegate, TestReceiveWriteLoco) {
   _stream << "<w 1>";
   _dccexProtocol.check();
 }
+
+/**
+ * @brief Test processing sensor broadcasts doesn't seg fault when no delegate
+ */
+TEST_F(TestHarnessNoDelegate, TestNoSensorBroadcasts) {
+  // Simulate receiving broadcasts
+  _stream << "<Q 100>";
+  _dccexProtocol.check();
+
+  _stream << "<q 200>";
+  _dccexProtocol.check();
+}

--- a/test/test_Route/test_RouteParsing.cpp
+++ b/test/test_Route/test_RouteParsing.cpp
@@ -107,3 +107,21 @@ TEST_F(RouteTests, parseRouteEntriesOutOfOrder) {
   EXPECT_TRUE(_dccexProtocol.receivedRouteList());
   EXPECT_EQ(_dccexProtocol.getRouteCount(), 3);
 }
+
+/**
+ * @brief Test a route entry for an id not in the list is accepted without requesting details
+ */
+TEST_F(RouteTests, parseRouteEntryUnknownId) {
+  // Received flag should be false to start
+  EXPECT_FALSE(_dccexProtocol.receivedRouteList());
+
+  // Route entry response for an unknown id
+  _stream << R"(<jA 999 R "Route 999">)";
+  EXPECT_CALL(_delegate, receivedRouteList()).Times(Exactly(1));
+  _dccexProtocol.check();
+
+  // The route list is received, nothing is created, and no entry details are requested
+  EXPECT_TRUE(_dccexProtocol.receivedRouteList());
+  EXPECT_EQ(_dccexProtocol.getRouteCount(), 0);
+  EXPECT_EQ(_stream.getOutput(), "");
+}

--- a/test/test_Turnout/test_TurnoutParsing.cpp
+++ b/test/test_Turnout/test_TurnoutParsing.cpp
@@ -107,3 +107,13 @@ TEST_F(TurnoutTests, parseTurnoutEntriesOutOfOrder) {
   EXPECT_TRUE(_dccexProtocol.receivedTurnoutList());
   EXPECT_EQ(_dccexProtocol.getTurnoutCount(), 3);
 }
+
+/**
+ * @brief Test a turnout entry for an unregistered id does not crash and leaves the list empty
+ */
+TEST_F(TurnoutTests, parseTurnoutEntryUnknownId) {
+  _stream << R"(<jT 999 C "Unknown">)";
+  _dccexProtocol.check();
+  EXPECT_EQ(_stream.getOutput(), "");
+  EXPECT_EQ(_dccexProtocol.getTurnoutCount(), 0);
+}

--- a/test/test_Turnout/test_Turnouts.cpp
+++ b/test/test_Turnout/test_Turnouts.cpp
@@ -442,3 +442,17 @@ TEST_F(TurnoutTests, refreshTurnoutListResetsAndReRequests) {
   _dccexProtocol.getLists(false, true, false, false);
   EXPECT_EQ(_stream.getOutput(), "<J T>");
 }
+
+/**
+ * @brief Test a turnout broadcast for an unregistered id walks the list and is ignored
+ */
+TEST_F(TurnoutTests, TestBroadcastUnknownTurnoutId) {
+  Turnout *turnout100 = new Turnout(100, false);
+  EXPECT_CALL(_delegate, receivedTurnoutAction(_, _)).Times(0);
+  _stream << "<H 999 1>";
+  _dccexProtocol.check();
+  EXPECT_FALSE(turnout100->getThrown());
+
+  delete turnout100;
+  EXPECT_EQ(Turnout::getFirst(), nullptr);
+}

--- a/test/test_Turntable/test_TurntableParsing.cpp
+++ b/test/test_Turntable/test_TurntableParsing.cpp
@@ -181,3 +181,49 @@ TEST_F(TurntableTests, orphanedIndexEntryLeak) {
   // Cleanup
   Turntable::clearTurntableList();
 }
+
+/**
+ * @brief Test a turntable entry for an id not in the list is accepted without creating a turntable
+ */
+TEST_F(TurntableTests, parseTurntableEntryUnknownId) {
+  // Turntable entry response for an unknown id
+  _stream << R"(<jO 999 1 1 1 "Unknown">)";
+  EXPECT_CALL(_delegate, receivedTurntableList()).Times(0);
+  _dccexProtocol.check();
+
+  // No turntable is created, no list is completed, and no detail requests are made
+  EXPECT_EQ(_dccexProtocol.getTurntableCount(), 0);
+  EXPECT_EQ(_stream.getOutput(), "");
+}
+
+/**
+ * @brief Test a turntable broadcast for an unregistered id is forwarded without modifying any turntable
+ */
+TEST_F(TurntableTests, turntableBroadcastUnknownId) {
+  // Set up a dummy turntable
+  Turntable *tt = new Turntable(1);
+  tt->setIndex(2);
+  tt->setMoving(true);
+
+  // Simulate receiving a broadcast for an unregistered turntable
+  EXPECT_CALL(_delegate, receivedTurntableAction(999, 0, false)).Times(Exactly(1));
+  _stream << "<I 999 0 0>";
+  _dccexProtocol.check();
+
+  // The registered turntable must remain untouched
+  EXPECT_EQ(tt->getIndex(), 2);
+  EXPECT_TRUE(tt->isMoving());
+}
+
+/**
+ * @brief Test a position index entry with a numeric name is ignored
+ */
+TEST_F(TurntableTests, turntableIndexEntryNumericNameIgnored) {
+  // Simulate receiving a malformed index entry (numeric name parameter)
+  _stream << "<jP 1 0 0 45>";
+  EXPECT_CALL(_delegate, receivedTurntableList()).Times(0);
+  _dccexProtocol.check();
+
+  // Nothing is processed
+  EXPECT_EQ(_stream.getOutput(), "");
+}


### PR DESCRIPTION
- Add JMRI type sensor support for broadcasts, noting objects are not created:
                - requestJMRISensorList()
        - DCCEXProtocolDelegate new method receivedJMRISensorBroadcast(int id, JMRISensorState state)