### PR TITLE
Add protocol interoperability boundary tests

### DIFF
--- a/test/test_General/test_InteropBoundary.cpp
+++ b/test/test_General/test_InteropBoundary.cpp
@@ -1,0 +1,25 @@
+#include "../setup/DCCEXProtocolTests.h"
+
+namespace {
+static_assert(PowerOff == 0 && PowerOn == 1 && PowerUnknown == 2);
+static_assert(MAIN == 0 && PROG == 1 && DC == 2 && DCX == 3 && NONE == 4);
+}
+
+TEST_F(DCCEXProtocolTests, mixedInboundFramesRemainIndependentlyDispatchable) {
+  Turnout turnout(7, false);
+
+  EXPECT_CALL(_delegate, receivedTrackPower(PowerOn));
+  EXPECT_CALL(_delegate, receivedTurnoutAction(7, true));
+  EXPECT_CALL(_delegate, receivedJMRISensorBroadcast(9, Activated));
+
+  _stream << "<p1><H 7 1><Q 9>";
+  _dccexProtocol.check();
+}
+
+TEST_F(DCCEXProtocolTests, outboundFramesStayDistinctAcrossFeatureFamilies) {
+  _dccexProtocol.powerOn();
+  _dccexProtocol.throwTurnout(7);
+  _dccexProtocol.readCV(29);
+
+  EXPECT_EQ(_stream.getOutput(), "<1><T 7 1><R 29>");
+}


### PR DESCRIPTION
## Summary

Adds a focused DCCEXProtocol interoperability-boundary test in test/test_General/test_InteropBoundary.cpp. It exercises existing public protocol behavior without changing the protocol API.

## References and exclusions

- No matching DCCEXProtocol issue was identified in the live audit; this is the planned dedicated interoperability-test item.
- No superseded PR was identified.
- CommandStation-side interoperability work remains separate.
- No automatic closing keyword is used because this PR adds only one protocol-test boundary and does not claim to complete the broader interoperability portfolio.
- Personal integration code and unrelated protocol behavior are explicitly out of scope.

## Validation evidence

- Fresh branch based on upstream main; origin is BanjoR/DCCEXProtocol and upstream is DCC-EX/DCCEXProtocol.
- Exact one-file allowlist, static API/parser review, Python syntax audit, whitespace checks, and git diff --check: passed.
- The standalone branch does not include the independent Windows/MSVC/Clang-cl portability correction; that separately scoped toolchain work is in [DCCEXProtocol PR #78](https://github.com/DCC-EX/DCCEXProtocol/pull/78), whose current head is 72a23c2.
- Current exact-head fork CI passed: [PlatformIO Testing run 31950947271](https://github.com/BanjoR/DCCEXProtocol/actions/runs/31950947271) completed 401/401 test cases successfully, and [Arduino-lint run 31950947240](https://github.com/BanjoR/DCCEXProtocol/actions/runs/31950947240) passed.
- These current runs prove the interoperability test compiles and passes in the repository's hosted PlatformIO/native suite. They do not claim standalone Windows/MSVC/Clang-cl portability before the separately scoped #78 work is merged or an equivalent configuration is used.
- PR metadata: [DCCEXProtocol PR #77](https://github.com/DCC-EX/DCCEXProtocol/pull/77) is a BanjoR PR targeting DCC-EX main.

## Hardware validation

Not run - no hardware is available. Maintainer bench criteria: connect a supported EX-CommandStation and exercise representative command, response, broadcast, and callback sequences while confirming frame separation and reconnect behavior.